### PR TITLE
chore: run tests before deploy

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -3,14 +3,26 @@ name: Fly Deploy
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: fly-deploy
-  cancel-in-progress: false
+  group: fly-deploy-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun test
+
   deploy:
+    if: github.event_name != 'pull_request'
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build:css": "bun x @tailwindcss/cli -i src/styles/app.css -o public/styles.css --minify",
     "dev:css": "bun x @tailwindcss/cli -i src/styles/app.css -o public/styles.css --watch",
     "dev": "bun run build:css && bun run --hot src/index.ts",
-    "start": "bun run build:css && bun run src/index.ts"
+    "start": "bun run build:css && bun run src/index.ts",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary
- add a package `test` script so `bun run test` works locally
- split the deploy workflow into a PR-safe `test` job and a main-only `deploy` job
- run Bun tests before Fly deploys from main

## Test Plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run test`
- [x] independent code review pass