### PR TITLE
Fix stale GTFS data causing missing buses

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -127,7 +127,7 @@ app.get("/push-sw.js", async (c) => {
 // Health check endpoint — verifies DB is queryable
 // Fly.io hits this to decide if the machine is healthy
 import { verifyDatabase } from "./data/migrate.js";
-import { getMatchRate } from "./data/realtime.js";
+import { getMatchRate, isVehicleCacheWarm } from "./data/realtime.js";
 import { getTripLookup } from "./data/db.js";
 
 app.get("/health", async (c) => {
@@ -140,14 +140,16 @@ app.get("/health", async (c) => {
     }, 503);
   }
 
-  // GTFS staleness check — compare realtime trip IDs against DB
+  // GTFS staleness check — only when vehicle cache is already warm (no network call)
   let gtfs: { matchRate: number; matched: number; total: number; stale: boolean } | undefined;
-  try {
-    const tripLookup = getTripLookup();
-    const { matched, total, rate } = await getMatchRate(tripLookup);
-    gtfs = { matchRate: rate, matched, total, stale: rate < 0.5 };
-  } catch {
-    // Don't fail health check if realtime API is unreachable
+  if (isVehicleCacheWarm()) {
+    try {
+      const tripLookup = getTripLookup();
+      const { matched, total, rate } = await getMatchRate(tripLookup);
+      gtfs = { matchRate: rate, matched, total, stale: rate < 0.5 };
+    } catch {
+      // Don't fail health check if realtime data unavailable
+    }
   }
 
   return c.json({

--- a/src/app.ts
+++ b/src/app.ts
@@ -127,8 +127,10 @@ app.get("/push-sw.js", async (c) => {
 // Health check endpoint — verifies DB is queryable
 // Fly.io hits this to decide if the machine is healthy
 import { verifyDatabase } from "./data/migrate.js";
+import { getMatchRate } from "./data/realtime.js";
+import { getTripLookup } from "./data/db.js";
 
-app.get("/health", (c) => {
+app.get("/health", async (c) => {
   const dbCheck = verifyDatabase();
   if (!dbCheck.ok) {
     return c.json({
@@ -137,10 +139,22 @@ app.get("/health", (c) => {
       db: dbCheck,
     }, 503);
   }
+
+  // GTFS staleness check — compare realtime trip IDs against DB
+  let gtfs: { matchRate: number; matched: number; total: number; stale: boolean } | undefined;
+  try {
+    const tripLookup = getTripLookup();
+    const { matched, total, rate } = await getMatchRate(tripLookup);
+    gtfs = { matchRate: rate, matched, total, stale: rate < 0.5 };
+  } catch {
+    // Don't fail health check if realtime API is unreachable
+  }
+
   return c.json({
     status: "healthy",
     timestamp: new Date().toISOString(),
     db: { version: dbCheck.version, tables: dbCheck.tables },
+    ...(gtfs && { gtfs }),
   });
 });
 

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -388,6 +388,11 @@ class MARTADatabase {
     return result;
   }
 
+  invalidateCaches() {
+    this.tripLookupCache = null;
+    this._allStopsCache = null;
+  }
+
   close() {
     this.db.close();
     }
@@ -490,6 +495,10 @@ export function getTripStopSequences(tripIds: string[]) {
 
 export function getAllStopsWithRoutes() {
   return db.getAllStopsWithRoutes();
+}
+
+export function invalidateCaches() {
+  db.invalidateCaches();
 }
 
 export type { Route, Stop, Trip, RouteStop, RouteDetail };

--- a/src/data/gtfs-import.ts
+++ b/src/data/gtfs-import.ts
@@ -586,7 +586,18 @@ async function main() {
   }
 }
 
+let refreshing = false;
+
+export function isRefreshing(): boolean {
+  return refreshing;
+}
+
 export async function refreshGTFS() {
+  if (refreshing) {
+    console.log("🔄 GTFS refresh already in progress, skipping");
+    return;
+  }
+  refreshing = true;
   console.log("🔄 GTFS refresh starting...");
 
   // Use DB directory for temp files (persistent volume on Fly.io)
@@ -641,6 +652,7 @@ export async function refreshGTFS() {
     console.error("❌ GTFS refresh failed:", error);
   } finally {
     importer.close();
+    refreshing = false;
   }
 }
 

--- a/src/data/realtime.ts
+++ b/src/data/realtime.ts
@@ -2,8 +2,6 @@ import { load } from "protobufjs";
 import path from "path";
 import { getScheduledArrivals, getStopIdsByName, getTripStopSequences, type Trip } from "./db";
 import { computeETA, parseTimeToSec, type TripStop } from "./eta";
-import { refreshGTFS } from "./gtfs-import.js";
-
 const VEHICLE_POSITIONS_URL = "https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/vehicle/vehiclepositions.pb";
 const TRIP_UPDATES_URL = "https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/tripupdate/tripupdates.pb";
 const CACHE_DURATION = 30 * 1000; // 30 seconds
@@ -547,8 +545,6 @@ export function isVehicleCacheWarm(): boolean {
 // GTFS STALENESS DETECTION
 // ─────────────────────────────────────
 
-let gtfsRefreshing = false;
-
 export async function getMatchRate(tripLookup: Map<string, Trip>): Promise<{matched: number, total: number, rate: number}> {
   const entities = await realtimeService.getVehiclePositions();
   let matched = 0;
@@ -564,17 +560,6 @@ export async function getMatchRate(tripLookup: Map<string, Trip>): Promise<{matc
   }
 
   const rate = total === 0 ? 1 : matched / total;
-
-  // Auto-refresh when match rate drops below 50%
-  if (rate < 0.5 && total > 0 && !gtfsRefreshing) {
-    gtfsRefreshing = true;
-    console.warn(`⚠️ GTFS match rate critically low: ${matched}/${total} (${(rate * 100).toFixed(1)}%) — triggering auto-refresh`);
-    refreshGTFS()
-      .then(() => console.log("✅ Auto GTFS refresh complete"))
-      .catch((err) => console.error("❌ Auto GTFS refresh failed:", err))
-      .finally(() => { gtfsRefreshing = false; });
-  }
-
   return { matched, total, rate };
 }
 

--- a/src/data/realtime.ts
+++ b/src/data/realtime.ts
@@ -2,6 +2,7 @@ import { load } from "protobufjs";
 import path from "path";
 import { getScheduledArrivals, getStopIdsByName, getTripStopSequences, type Trip } from "./db";
 import { computeETA, parseTimeToSec, type TripStop } from "./eta";
+import { refreshGTFS } from "./gtfs-import.js";
 
 const VEHICLE_POSITIONS_URL = "https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/vehicle/vehiclepositions.pb";
 const TRIP_UPDATES_URL = "https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/tripupdate/tripupdates.pb";
@@ -117,7 +118,7 @@ class RealtimeDataService {
   private vehicleFetching = false;
   private tripUpdatesFetching = false;
 
-  private async getVehiclePositions(): Promise<any[]> {
+  async getVehiclePositions(): Promise<any[]> {
     if (this.isCacheValid(this.vehicleCache)) {
       return this.vehicleCache!.data;
     }
@@ -540,6 +541,41 @@ export async function getAllVehicles(tripLookup: Map<string, Trip>): Promise<Veh
 // Metrics uses this to avoid API calls when the app is idle.
 export function isVehicleCacheWarm(): boolean {
   return realtimeService.isCacheWarm();
+}
+
+// ─────────────────────────────────────
+// GTFS STALENESS DETECTION
+// ─────────────────────────────────────
+
+let gtfsRefreshing = false;
+
+export async function getMatchRate(tripLookup: Map<string, Trip>): Promise<{matched: number, total: number, rate: number}> {
+  const entities = await realtimeService.getVehiclePositions();
+  let matched = 0;
+  let total = 0;
+
+  for (const entity of entities) {
+    const tripId = entity.vehicle?.trip?.tripId;
+    if (!tripId) continue;
+    total++;
+    if (tripLookup.has(tripId)) {
+      matched++;
+    }
+  }
+
+  const rate = total === 0 ? 1 : matched / total;
+
+  // Auto-refresh when match rate drops below 50%
+  if (rate < 0.5 && total > 0 && !gtfsRefreshing) {
+    gtfsRefreshing = true;
+    console.warn(`⚠️ GTFS match rate critically low: ${matched}/${total} (${(rate * 100).toFixed(1)}%) — triggering auto-refresh`);
+    refreshGTFS()
+      .then(() => console.log("✅ Auto GTFS refresh complete"))
+      .catch((err) => console.error("❌ Auto GTFS refresh failed:", err))
+      .finally(() => { gtfsRefreshing = false; });
+  }
+
+  return { matched, total, rate };
 }
 
 export type { VehiclePosition, PredictionUpdate, ArrivalPrediction };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,10 @@ runMigrations(); // throws on failure → process crashes → no server bind →
 // ── Safe to import DB-dependent modules now ──
 import app from "./app.js";
 import { Cron } from "croner";
-import { refreshGTFS } from "./data/gtfs-import.js";
+import { refreshGTFS, isRefreshing } from "./data/gtfs-import.js";
 import { collectMetrics, cleanOldMetrics } from "./data/metrics.js";
+import { getMatchRate, isVehicleCacheWarm } from "./data/realtime.js";
+import { getTripLookup, invalidateCaches } from "./data/db.js";
 
 const port = parseInt(process.env.PORT || "4200");
 
@@ -23,6 +25,7 @@ console.log(`🌐 Server: http://localhost:${port}`);
 const gtfsCron = new Cron("0 3 * * *", { timezone: "America/New_York" }, async () => {
   console.log("⏰ Daily GTFS refresh triggered");
   await refreshGTFS();
+  invalidateCaches();
   cleanOldMetrics(); // prune old metrics during daily maintenance
 });
 console.log(`📅 GTFS refresh scheduled: next run ${gtfsCron.nextRun()?.toISOString() ?? "unknown"}`);
@@ -59,6 +62,7 @@ const gtfsCheckCron = new Cron("0 * * * *", { timezone: "America/New_York" }, as
       lastGtfsLastModified = lastModified;
       lastGtfsContentLength = contentLength;
       await refreshGTFS();
+      invalidateCaches();
     }
   } catch (err) {
     console.error("❌ GTFS HEAD check error:", err);
@@ -69,6 +73,19 @@ console.log(`🔍 GTFS change check: hourly (next ${gtfsCheckCron.nextRun()?.toI
 // Metrics collection: every 5 minutes during operation
 const metricsCron = new Cron("*/5 * * * *", { timezone: "America/New_York" }, async () => {
   await collectMetrics();
+
+  // Check GTFS staleness when vehicle cache is warm (users are active)
+  if (isVehicleCacheWarm() && !isRefreshing()) {
+    try {
+      const tripLookup = getTripLookup();
+      const { matched, total, rate } = await getMatchRate(tripLookup);
+      if (rate < 0.5 && total > 0) {
+        console.warn(`⚠️ GTFS match rate critically low: ${matched}/${total} (${(rate * 100).toFixed(1)}%) — triggering auto-refresh`);
+        await refreshGTFS();
+        invalidateCaches();
+      }
+    } catch {}
+  }
 });
 console.log(`📊 Metrics collection: every 5 min (next ${metricsCron.nextRun()?.toISOString() ?? "unknown"})`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,13 +19,52 @@ const port = parseInt(process.env.PORT || "4200");
 console.log(`🔑 API Key: ${process.env.MARTA_API_KEY ? "✓ Set" : "❌ Missing"}`);
 console.log(`🌐 Server: http://localhost:${port}`);
 
-// Weekly GTFS refresh: Sunday 3am ET
-const gtfsCron = new Cron("0 3 * * 0", { timezone: "America/New_York" }, async () => {
-  console.log("⏰ Weekly GTFS refresh triggered");
+// Daily GTFS refresh: every day at 3am ET
+const gtfsCron = new Cron("0 3 * * *", { timezone: "America/New_York" }, async () => {
+  console.log("⏰ Daily GTFS refresh triggered");
   await refreshGTFS();
-  cleanOldMetrics(); // prune old metrics during weekly maintenance
+  cleanOldMetrics(); // prune old metrics during daily maintenance
 });
 console.log(`📅 GTFS refresh scheduled: next run ${gtfsCron.nextRun()?.toISOString() ?? "unknown"}`);
+
+// Hourly GTFS change check: HEAD request to detect upstream schedule changes
+let lastGtfsLastModified: string | null = null;
+let lastGtfsContentLength: string | null = null;
+const GTFS_URL = "https://itsmarta.com/google_transit_feed/google_transit.zip";
+
+const gtfsCheckCron = new Cron("0 * * * *", { timezone: "America/New_York" }, async () => {
+  try {
+    const resp = await fetch(GTFS_URL, { method: "HEAD" });
+    if (!resp.ok) {
+      console.warn(`⚠️ GTFS HEAD check failed: ${resp.status}`);
+      return;
+    }
+    const lastModified = resp.headers.get("last-modified");
+    const contentLength = resp.headers.get("content-length");
+
+    // First run: just record values, don't trigger refresh
+    if (lastGtfsLastModified === null && lastGtfsContentLength === null) {
+      lastGtfsLastModified = lastModified;
+      lastGtfsContentLength = contentLength;
+      console.log(`📋 GTFS baseline recorded — Last-Modified: ${lastModified}, Content-Length: ${contentLength}`);
+      return;
+    }
+
+    const changed =
+      (lastModified !== null && lastModified !== lastGtfsLastModified) ||
+      (contentLength !== null && contentLength !== lastGtfsContentLength);
+
+    if (changed) {
+      console.log(`🔔 GTFS change detected — Last-Modified: ${lastGtfsLastModified} → ${lastModified}, Content-Length: ${lastGtfsContentLength} → ${contentLength}`);
+      lastGtfsLastModified = lastModified;
+      lastGtfsContentLength = contentLength;
+      await refreshGTFS();
+    }
+  } catch (err) {
+    console.error("❌ GTFS HEAD check error:", err);
+  }
+});
+console.log(`🔍 GTFS change check: hourly (next ${gtfsCheckCron.nextRun()?.toISOString() ?? "unknown"})`);
 
 // Metrics collection: every 5 minutes during operation
 const metricsCron = new Cron("*/5 * * * *", { timezone: "America/New_York" }, async () => {


### PR DESCRIPTION
## Summary

Fixes #3 — buses disappear when MARTA publishes new GTFS schedules because trip IDs in the realtime feed no longer match the stale SQLite data.

- **Daily GTFS refresh** — cron changed from weekly (Sunday 3am) to daily (3am ET), reducing max stale window from 7 days to 1 day
- **Hourly GTFS change detection** — lightweight HEAD request checks `Last-Modified`/`Content-Length` headers on the GTFS ZIP; triggers `refreshGTFS()` only when the upstream file changes
- **Trip match rate monitoring** — new `getMatchRate()` function compares realtime trip IDs against the DB; auto-triggers refresh when match rate drops below 50%
- **Health endpoint enhancement** — `/health` now reports GTFS staleness info (`matchRate`, `matched`, `total`, `stale`)

## Test plan

- [x] All 27 existing tests pass
- [ ] Deploy and verify `/health` shows `gtfs` field with match rate
- [ ] Verify buses reappear after a GTFS refresh cycle
- [ ] Monitor logs for hourly GTFS change detection messages
- [ ] Verify auto-refresh triggers when match rate is critically low

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTEcwh3QCiB6Ywn6aFgYhJ)_