### PR TITLE
Fix missing buses after deploy with startup GTFS check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,31 @@ const metricsCron = new Cron("*/5 * * * *", { timezone: "America/New_York" }, as
 });
 console.log(`📊 Metrics collection: every 5 min (next ${metricsCron.nextRun()?.toISOString() ?? "unknown"})`);
 
+// Startup GTFS staleness check — catches stale data after deploys/restarts
+// without waiting for cron cycles (daily refresh, hourly check, or 5-min metrics)
+(async () => {
+  try {
+    const tripLookup = getTripLookup();
+    if (tripLookup.size === 0) {
+      console.log("📭 No trips in database — triggering initial GTFS import");
+      await refreshGTFS();
+      invalidateCaches();
+      return;
+    }
+
+    const { matched, total, rate } = await getMatchRate(tripLookup);
+    console.log(`📊 Startup match rate: ${matched}/${total} (${(rate * 100).toFixed(1)}%)`);
+
+    if (rate < 0.5 && total > 0) {
+      console.log("⚠️ GTFS data stale at startup — refreshing now");
+      await refreshGTFS();
+      invalidateCaches();
+    }
+  } catch (err) {
+    console.error("❌ Startup GTFS check failed:", err);
+  }
+})();
+
 export default {
   port,
   hostname: "0.0.0.0",


### PR DESCRIPTION
## Summary

Fixes #3 — buses still missing after PR #4's merge because no GTFS staleness check runs at startup.

- **Startup GTFS staleness check** — on boot, immediately fetches MARTA's realtime feed and compares trip IDs against the database. If match rate drops below 50%, triggers an immediate `refreshGTFS()` instead of waiting for cron cycles (daily at 3am, hourly HEAD check, or 5-min metrics).
- **Empty DB detection** — if the trips table is empty (fresh deploy without seed data), triggers an initial GTFS import immediately.

### Why PR #4 wasn't enough

PR #4 added three refresh triggers, but none fire immediately at startup:
1. **Daily cron** (3am ET) — up to 24h delay
2. **Hourly HEAD check** — records baseline on first run, won't trigger until *next* change
3. **Match rate check** (every 5 min) — only runs when vehicle cache is warm (requires a user visit first)

After a deploy with stale data, users see zero buses until one of these cycles fires. The startup check eliminates this gap.

## Test plan

- [x] All 27 existing tests pass
- [ ] Deploy and verify buses appear immediately (no 5-min wait)
- [ ] Verify startup logs show match rate check
- [ ] Verify no duplicate refresh if cron fires shortly after startup (guarded by `isRefreshing()`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDDi4WL3YWToTqAb4Psp45)_