### PR TITLE
Revert startup GTFS download, add diagnostic logging

### DIFF
--- a/src/data/realtime.ts
+++ b/src/data/realtime.ts
@@ -91,7 +91,7 @@ class RealtimeDataService {
     const response = await fetch(`${url}?apiKey=${this.apiKey}`);
     
     if (!response.ok) {
-      throw new Error(`Failed to fetch ${url}: ${response.status}`);
+      throw new Error(`HTTP ${response.status} ${response.statusText} from ${url.split('?')[0]}`);
     }
 
     const buffer = await response.arrayBuffer();
@@ -127,7 +127,7 @@ class RealtimeDataService {
       this.fetchProtobufData(VEHICLE_POSITIONS_URL).then(entities => {
         this.vehicleCache = { data: entities, timestamp: Date.now() };
         this.vehicleFetching = false;
-      }).catch((err) => { console.error('Vehicle fetch failed:', err); this.vehicleFetching = false; });
+      }).catch((err) => { console.error('❌ Vehicle position fetch failed:', err.message || err); this.vehicleFetching = false; });
       return this.vehicleCache!.data;
     }
 
@@ -147,7 +147,7 @@ class RealtimeDataService {
       this.fetchProtobufData(TRIP_UPDATES_URL).then(entities => {
         this.tripUpdatesCache = { data: entities, timestamp: Date.now() };
         this.tripUpdatesFetching = false;
-      }).catch((err) => { console.error('Trip updates fetch failed:', err); this.tripUpdatesFetching = false; });
+      }).catch((err) => { console.error('❌ Trip updates fetch failed:', err.message || err); this.tripUpdatesFetching = false; });
       return this.tripUpdatesCache!.data;
     }
 
@@ -160,13 +160,15 @@ class RealtimeDataService {
     const entities = await this.getVehiclePositions();
     const timestamp = Date.now();
 
-    return entities
-      .filter(entity => {
-        if (!entity.vehicle?.trip?.tripId || !entity.vehicle?.position) return false;
-        const trip = tripLookup.get(entity.vehicle.trip.tripId);
-        return trip?.route_id === routeId;
-      })
-      .map(entity => {
+    const withData = entities.filter(e => e.vehicle?.trip?.tripId && e.vehicle?.position);
+    const matched = withData.filter(e => tripLookup.get(e.vehicle.trip.tripId)?.route_id === routeId);
+
+    if (matched.length === 0 && entities.length > 0) {
+      const dbHits = withData.filter(e => tripLookup.has(e.vehicle.trip.tripId)).length;
+      console.warn(`🔍 getVehicles(${routeId}): ${entities.length} raw entities, ${withData.length} with trip+position, ${dbHits} matched any DB trip, 0 matched this route`);
+    }
+
+    return matched.map(entity => {
         const vehicle = entity.vehicle;
         const trip = tripLookup.get(vehicle.trip.tripId);
         
@@ -226,12 +228,14 @@ class RealtimeDataService {
     const entities = await this.getVehiclePositions();
     const timestamp = Date.now();
 
-    return entities
-      .filter(entity => {
-        if (!entity.vehicle?.trip?.tripId || !entity.vehicle?.position) return false;
-        return tripLookup.has(entity.vehicle.trip.tripId);
-      })
-      .map(entity => {
+    const withData = entities.filter(e => e.vehicle?.trip?.tripId && e.vehicle?.position);
+    const matched = withData.filter(e => tripLookup.has(e.vehicle.trip.tripId));
+
+    if (matched.length === 0 && entities.length > 0) {
+      console.warn(`🔍 getAllVehicles: ${entities.length} raw entities, ${withData.length} with trip+position, 0 matched any DB trip (${tripLookup.size} trips in DB)`);
+    }
+
+    return matched.map(entity => {
         const vehicle = entity.vehicle;
         const trip = tripLookup.get(vehicle.trip.tripId)!;
         const vehicleTimestamp = vehicle.timestamp ? parseInt(vehicle.timestamp) * 1000 : timestamp;

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,31 +89,6 @@ const metricsCron = new Cron("*/5 * * * *", { timezone: "America/New_York" }, as
 });
 console.log(`📊 Metrics collection: every 5 min (next ${metricsCron.nextRun()?.toISOString() ?? "unknown"})`);
 
-// Startup GTFS staleness check — catches stale data after deploys/restarts
-// without waiting for cron cycles (daily refresh, hourly check, or 5-min metrics)
-(async () => {
-  try {
-    const tripLookup = getTripLookup();
-    if (tripLookup.size === 0) {
-      console.log("📭 No trips in database — triggering initial GTFS import");
-      await refreshGTFS();
-      invalidateCaches();
-      return;
-    }
-
-    const { matched, total, rate } = await getMatchRate(tripLookup);
-    console.log(`📊 Startup match rate: ${matched}/${total} (${(rate * 100).toFixed(1)}%)`);
-
-    if (rate < 0.5 && total > 0) {
-      console.log("⚠️ GTFS data stale at startup — refreshing now");
-      await refreshGTFS();
-      invalidateCaches();
-    }
-  } catch (err) {
-    console.error("❌ Startup GTFS check failed:", err);
-  }
-})();
-
 export default {
   port,
   hostname: "0.0.0.0",


### PR DESCRIPTION
## Summary

- **Reverts PR #5's startup GTFS download** — removes the startup IIFE that downloaded + imported the full GTFS ZIP (~10MB) on every deploy/restart. This was too resource-intensive and didn't address the actual root cause (see investigation on #3).

- **Adds diagnostic logging at three silent-drop points** in the realtime pipeline so we can distinguish between "MARTA API is failing" vs "trip IDs don't match" from Fly.io logs:
  - `getVehicles()` — logs raw entity count, valid count, and DB match count when 0 vehicles match a route
  - `getAllVehicles()` — same diagnostic for the metrics path
  - `fetchProtobufData()` — improved error messages with HTTP status text, strips API key from logged URLs

Addresses [issue #3](https://github.com/jakswa/pullcord/issues/3) — specifically the owner's request to undo PR #5 and investigate root cause before further implementation.

## Test plan

- [x] All 27 existing tests pass
- [ ] Deploy and check Fly.io logs for diagnostic output
- [ ] Use log output to determine which hypothesis (API key, IP blocking, or trip ID mismatch) is the actual root cause

https://claude.ai/code/session_01RwSozBg3C1CiQiqFbMs9kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwSozBg3C1CiQiqFbMs9kL)_