### PR TITLE
Fix GTFS refresh lock-up + add diagnostic endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -129,6 +129,7 @@ app.get("/push-sw.js", async (c) => {
 import { verifyDatabase } from "./data/migrate.js";
 import { getMatchRate, isVehicleCacheWarm } from "./data/realtime.js";
 import { getTripLookup } from "./data/db.js";
+import { isRefreshing } from "./data/gtfs-import.js";
 
 app.get("/health", async (c) => {
   const dbCheck = verifyDatabase();
@@ -158,6 +159,76 @@ app.get("/health", async (c) => {
     db: { version: dbCheck.version, tables: dbCheck.tables },
     ...(gtfs && { gtfs }),
   });
+});
+
+// Diagnostic endpoint — actively probes MARTA realtime API and reports detailed status
+app.get("/health/diag", async (c) => {
+  const VEHICLE_POSITIONS_URL = "https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/vehicle/vehiclepositions.pb";
+  const apiKey = process.env.MARTA_API_KEY || "";
+
+  const diag: Record<string, unknown> = {
+    timestamp: new Date().toISOString(),
+    apiKeyPresent: apiKey.length > 0,
+    refreshLocked: isRefreshing(),
+  };
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    const url = `${VEHICLE_POSITIONS_URL}?apiKey=${apiKey}`;
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    diag.apiReachable = true;
+    diag.httpStatus = response.status;
+
+    if (!response.ok) {
+      diag.error = `HTTP ${response.status} ${response.statusText}`;
+      return c.json(diag);
+    }
+
+    // Decode protobuf
+    const { load } = await import("protobufjs");
+    const path = await import("path");
+    const protoPath = path.join(process.cwd(), "gtfs-realtime.proto");
+    const protoRoot = await load(protoPath);
+    const FeedMessage = protoRoot.lookupType("transit_realtime.FeedMessage");
+
+    const buffer = await response.arrayBuffer();
+    const message = FeedMessage.decode(new Uint8Array(buffer));
+    const entities: any[] = message.entity || [];
+
+    diag.rawEntities = entities.length;
+
+    // Count entities with valid trip + position
+    const withTripAndPosition = entities.filter(
+      (e: any) => e.vehicle?.trip?.tripId && e.vehicle?.position
+    );
+    diag.withTripAndPosition = withTripAndPosition.length;
+
+    // Compare against trip lookup
+    const tripLookup = getTripLookup();
+    diag.dbTripCount = tripLookup.size;
+
+    let matched = 0;
+    for (const e of withTripAndPosition) {
+      if (tripLookup.has(e.vehicle.trip.tripId)) {
+        matched++;
+      }
+    }
+    diag.matched = matched;
+    diag.matchRate = withTripAndPosition.length === 0
+      ? 0
+      : Math.round((matched / withTripAndPosition.length) * 1000) / 1000;
+  } catch (err: any) {
+    diag.apiReachable = false;
+    diag.error = err?.name === "AbortError"
+      ? "Request timed out after 5000ms"
+      : (err?.message || String(err));
+  }
+
+  return c.json(diag);
 });
 
 // Error handling

--- a/src/data/gtfs-import.ts
+++ b/src/data/gtfs-import.ts
@@ -598,60 +598,67 @@ export async function refreshGTFS() {
     return;
   }
   refreshing = true;
-  console.log("🔄 GTFS refresh starting...");
-
-  // Use DB directory for temp files (persistent volume on Fly.io)
-  const dataDir = path.dirname(DB_PATH);
-
-  // Download zip with timeout
-  const GTFS_URL = "https://itsmarta.com/google_transit_feed/google_transit.zip";
-  const zipPath = path.join(dataDir, "gtfs.zip");
-  console.log(`📥 Downloading GTFS from ${GTFS_URL}...`);
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 60_000);
   try {
-    const resp = await fetch(GTFS_URL, { signal: controller.signal });
-    if (!resp.ok) throw new Error(`GTFS download failed: ${resp.status}`);
-    const buf = await resp.arrayBuffer();
-    await Bun.write(zipPath, buf);
-    console.log(`✓ Downloaded ${(buf.byteLength / 1024 / 1024).toFixed(1)}MB`);
+    console.log("🔄 GTFS refresh starting...");
+
+    // Use DB directory for temp files (persistent volume on Fly.io)
+    const dataDir = path.dirname(DB_PATH);
+
+    // Download zip with timeout
+    const GTFS_URL = "https://itsmarta.com/google_transit_feed/google_transit.zip";
+    const zipPath = path.join(dataDir, "gtfs.zip");
+    console.log(`📥 Downloading GTFS from ${GTFS_URL}...`);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 60_000);
+    try {
+      const resp = await fetch(GTFS_URL, { signal: controller.signal });
+      if (!resp.ok) throw new Error(`GTFS download failed: ${resp.status}`);
+      const buf = await resp.arrayBuffer();
+      await Bun.write(zipPath, buf);
+      console.log(`✓ Downloaded ${(buf.byteLength / 1024 / 1024).toFixed(1)}MB`);
+    } catch (error) {
+      console.error("❌ GTFS download failed:", error);
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    // Extract zip — try unzip (Docker/Alpine), fall back to python3 (dev)
+    const gtfsDir = path.join(dataDir, "gtfs");
+    await fs.promises.mkdir(gtfsDir, { recursive: true });
+    try {
+      const proc = Bun.spawn(["unzip", "-o", zipPath, "-d", gtfsDir]);
+      const code = await proc.exited;
+      if (code !== 0) throw new Error(`unzip exited ${code}`);
+    } catch (error) {
+      console.error("❌ GTFS extraction failed, trying python3 fallback:", error);
+      const proc = Bun.spawn(["python3", "-c", `import zipfile; zipfile.ZipFile("${zipPath}").extractall("${gtfsDir}")`]);
+      const code = await proc.exited;
+      if (code !== 0) throw new Error("Both unzip and python3 extraction failed");
+    }
+    await fs.promises.unlink(zipPath);
+
+    // Run import
+    const importer = new GTFSImporter();
+    try {
+      await importer.importRoutes();
+      await importer.importStops(); // includes atomic group_id assignment
+      await importer.importCalendar();
+      await importer.importCalendarDates();
+      await importer.importTrips();
+      await importer.importShapes();
+      await importer.importStopTimes();
+      importer.buildRouteStops();
+      importer.cleanExpiredServices();
+      importer.buildTransferLookup();
+      importer.printStats();
+      console.log("✅ GTFS refresh complete!");
+    } catch (error) {
+      console.error("❌ GTFS refresh failed:", error);
+    } finally {
+      importer.close();
+    }
   } finally {
-    clearTimeout(timeout);
-  }
-
-  // Extract zip — try unzip (Docker/Alpine), fall back to python3 (dev)
-  const gtfsDir = path.join(dataDir, "gtfs");
-  await fs.promises.mkdir(gtfsDir, { recursive: true });
-  try {
-    const proc = Bun.spawn(["unzip", "-o", zipPath, "-d", gtfsDir]);
-    const code = await proc.exited;
-    if (code !== 0) throw new Error(`unzip exited ${code}`);
-  } catch {
-    const proc = Bun.spawn(["python3", "-c", `import zipfile; zipfile.ZipFile("${zipPath}").extractall("${gtfsDir}")`]);
-    const code = await proc.exited;
-    if (code !== 0) throw new Error("Both unzip and python3 extraction failed");
-  }
-  await fs.promises.unlink(zipPath);
-
-  // Run import
-  const importer = new GTFSImporter();
-  try {
-    await importer.importRoutes();
-    await importer.importStops(); // includes atomic group_id assignment
-    await importer.importCalendar();
-    await importer.importCalendarDates();
-    await importer.importTrips();
-    await importer.importShapes();
-    await importer.importStopTimes();
-    importer.buildRouteStops();
-    importer.cleanExpiredServices();
-    importer.buildTransferLookup();
-    importer.printStats();
-    console.log("✅ GTFS refresh complete!");
-  } catch (error) {
-    console.error("❌ GTFS refresh failed:", error);
-  } finally {
-    importer.close();
     refreshing = false;
   }
 }


### PR DESCRIPTION
## Summary

**Root cause fix:** `refreshGTFS()` had a bug where the `refreshing` mutex flag would get stuck `true` forever if the download or extraction step failed. Once stuck, ALL future GTFS refresh attempts (daily cron, hourly change detection, auto-refresh on low match rate) silently skip — permanently preventing schedule updates until a process restart.

**Diagnostic endpoint:** Adds `GET /health/diag` that actively probes the MARTA realtime API and reports exactly what's happening — API reachability, HTTP status, entity count, trip match rate, DB trip count, and whether the refresh lock is stuck. One `curl` gives instant root cause visibility.

### Changes

1. **`src/data/gtfs-import.ts`** — Wrap entire `refreshGTFS()` body in `try/finally` to guarantee `refreshing = false` runs. Add error logging for download/extraction failures.

2. **`src/app.ts`** — Add `/health/diag` endpoint with 5s timeout probe of MARTA API, protobuf decode, and trip match analysis.

### Why this matters for #3

The previous investigation identified 3 hypotheses (API key, IP blocking, trip ID mismatch). This PR adds a **4th**: the refresh lock got permanently stuck after a transient download failure, preventing GTFS from ever updating. The diagnostic endpoint lets you verify all 4 hypotheses with a single `curl https://bus.marta.io/health/diag`.

## Test plan

- [x] All 27 existing tests pass
- [ ] Deploy and immediately `curl /health/diag` — response shows which hypothesis is correct
- [ ] If `refreshLocked: true` is reported, the bug fix takes effect on next deploy
- [ ] If `matchRate` is low with `apiReachable: true`, GTFS data is stale (refresh lock was the cause)
- [ ] If `apiReachable: false`, it's an API key or network issue

https://claude.ai/code/session_013YfWgX6N4nM6yR4ff9XCV7

---
_Generated by [Claude Code](https://claude.ai/code/session_013YfWgX6N4nM6yR4ff9XCV7)_