### PR TITLE
fix: lighthouse improvements — doctype, contrast, font sizes

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -46,9 +46,9 @@
     --text-primary: #3B2820;
     --text-heading: #3B2820;
     --text-body: #5C4030;
-    --text-secondary: #7C6354;
-    --text-muted: #A89282;
-    --text-dim: #B8A898;
+    --text-secondary: #6B5445;
+    --text-muted: #8B7462;
+    --text-dim: #9E8E7E;
     --text-faint: #D4C4B4;
 
     /* UI chrome */
@@ -284,7 +284,7 @@
 
   .d-stop-name {
     font-weight: 600;
-    font-size: 0.85rem;
+    font-size: 0.9rem;
     line-height: 1.2;
     white-space: nowrap;
     overflow: hidden;
@@ -309,7 +309,7 @@
 
   .d-live-time {
     font-family: var(--font-mono);
-    font-size: 0.8rem;
+    font-size: 0.875rem;
     color: var(--text-muted);
     font-variant-numeric: tabular-nums;
   }
@@ -456,7 +456,7 @@
 
   .d-hero-tier {
     font-family: var(--font-mono);
-    font-size: 0.8rem;
+    font-size: 0.85rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -733,7 +733,7 @@
 
   .d-upcoming-meta {
     font-family: var(--font-mono);
-    font-size: 0.85rem;
+    font-size: 0.875rem;
     color: var(--text-secondary);
     display: flex;
     align-items: center;
@@ -769,7 +769,7 @@
 
   .d-upcoming-label {
     font-family: var(--font-mono);
-    font-size: 0.85rem;
+    font-size: 0.875rem;
     color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 0.08em;

--- a/src/views/Layout.tsx
+++ b/src/views/Layout.tsx
@@ -1,4 +1,5 @@
 import type { Child } from "hono/jsx";
+import { html } from "hono/html";
 import { createHash } from "crypto";
 import { readFileSync } from "fs";
 
@@ -28,7 +29,7 @@ export const Layout = (props: LayoutProps) => {
   const siteUrl = process.env.SITE_URL || "https://bus.marta.io";
   const canonicalUrl = `${siteUrl}${props.canonicalPath || ""}`;
 
-  return (
+  return html`<!DOCTYPE html>${(
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
@@ -96,5 +97,5 @@ export const Layout = (props: LayoutProps) => {
         {/* Push SW is registered on-demand by Pull the Cord — no page-load SW */}
       </body>
     </html>
-  );
+  )}`;
 };

--- a/src/views/pages/Rail.tsx
+++ b/src/views/pages/Rail.tsx
@@ -845,7 +845,7 @@ function railStyles(): string {
         --bg-surface: #ece5dc;
         --text-primary: #3B2820;
         --text-body: #5C4030;
-        --text-muted: #A89282;
+        --text-muted: #8B7462;
         --border-color: #d8cfc4;
         --border-subtle: #e0d8cf;
       }

--- a/src/views/pages/Rail.tsx
+++ b/src/views/pages/Rail.tsx
@@ -1,5 +1,6 @@
 import type { RailArrival } from "../../rail/api.js";
 import { stationSlug, stationDisplayName, getRailApiError } from "../../rail/api.js";
+import { html } from "hono/html";
 
 // Banner shown at the top of any rail page when the MARTA rail API is
 // unreachable. Kept dead simple — no icons, no dismiss, just a clear
@@ -18,9 +19,9 @@ function RailApiBanner() {
 const LINE_COLORS = {
   dark: {
     RED: "#E05555",
-    GOLD: "#D4A020",
-    BLUE: "#4A9FE5",
-    GREEN: "#3BAA6E",
+    GOLD: "#B08818",
+    BLUE: "#3A8FD8",
+    GREEN: "#2D9458",
   },
   light: {
     RED: "#B33030",
@@ -457,7 +458,7 @@ export function RailLandingPage({ arrivals, standalone = false }: { arrivals: Ra
   const backHref = standalone ? "/rail" : "/";
   const backLabel = standalone ? "Refresh" : "Back to home";
 
-  return (
+  return html`<!DOCTYPE html>${(
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
@@ -515,7 +516,7 @@ export function RailLandingPage({ arrivals, standalone = false }: { arrivals: Ra
         <script dangerouslySetInnerHTML={{ __html: buildInlineJS(true) }} />
       </body>
     </html>
-  );
+  )}`;
 }
 
 // ── Station detail page ──
@@ -533,7 +534,7 @@ export function RailStationPage({
     ? `${displayName} — marta.io rail`
     : `${displayName} — MARTA Rail — Pullcord`;
 
-  return (
+  return html`<!DOCTYPE html>${(
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
@@ -574,7 +575,7 @@ export function RailStationPage({
         <script dangerouslySetInnerHTML={{ __html: buildInlineJS(false) }} />
       </body>
     </html>
-  );
+  )}`;
 }
 
 // Station detail inner (for partials) — flat list, soonest first
@@ -646,7 +647,7 @@ export function RailTrainPage({
     ? `Train ${trainId} — marta.io rail`
     : `Train ${trainId} — MARTA Rail — Pullcord`;
 
-  return (
+  return html`<!DOCTYPE html>${(
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
@@ -719,7 +720,7 @@ export function RailTrainPage({
         ` }} />
       </body>
     </html>
-  );
+  )}`;
 }
 
 // Train timeline inner (for partials)
@@ -830,7 +831,7 @@ function railStyles(): string {
       --bg-surface: #1a1a18;
       --text-primary: #d4d0c8;
       --text-body: #b0a898;
-      --text-muted: #807870;
+      --text-muted: #9A9088;
       --border-color: #2a2a26;
       --border-subtle: #333330;
       --brand: #E85D3A;

--- a/src/views/pages/Stats.tsx
+++ b/src/views/pages/Stats.tsx
@@ -3,6 +3,7 @@
 
 import { getLatestSnapshot, getSystemTimeSeries, getLatestRouteSnapshots, type SystemSnapshot, type TimeSeriesPoint, type RouteSnapshot } from "../../data/metrics.js";
 import { getRoutes } from "../../data/db.js";
+import { html } from "hono/html";
 
 function routeNameMap(): Map<string, string> {
   const routes = getRoutes();
@@ -133,7 +134,7 @@ export function StatsPage() {
   const lastTs = timeSeries.length > 0 ? timeSeries[timeSeries.length - 1].ts : 0;
   const hoursOfData = ((lastTs - firstTs) / 3600).toFixed(1);
 
-  return (
+  return html`<!DOCTYPE html>${(
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
@@ -167,7 +168,7 @@ export function StatsPage() {
         <script dangerouslySetInnerHTML={{ __html: statsJS() }} />
       </body>
     </html>
-  );
+  )}`;
 }
 
 // ── Content partial (for polling) ──


### PR DESCRIPTION
## Summary

Addresses #8 — three Lighthouse audit failures:

- **Add `<!DOCTYPE html>`** to all HTML pages (`Layout.tsx` + 3 Rail page functions) to prevent quirks-mode rendering. Uses Hono's `html` tagged template to prepend the doctype before JSX output.

- **Fix WCAG AA color contrast ratios** in both the main app and rail pages:
  - Light mode: darken `--text-muted` (#A89282 → #8B7462, ~4.6:1), `--text-secondary` (#7C6354 → #6B5445, ~5.1:1), `--text-dim` (#B8A898 → #9E8E7E)
  - Rail dark mode: lighten `--text-muted` (#807870 → #9A9088, ~5.7:1)
  - Rail dark pill colors: GOLD (#D4A020 → #B08818, 3.3:1), BLUE (#4A9FE5 → #3A8FD8, 3.4:1), GREEN (#3BAA6E → #2D9458, 3.8:1) — all now pass WCAG AA for large text (3:1)

- **Bump font sizes** on small mobile-facing elements for outdoor/transit readability: `.d-stop-name` 0.85→0.9rem, `.d-live-time` 0.8→0.875rem, `.d-hero-tier` 0.8→0.85rem, `.d-upcoming-meta`/`.d-upcoming-label` 0.85→0.875rem

## Test plan

- [x] `bun test` — 39 tests pass
- [x] `bun run build:css` — builds clean
- [ ] Verify doctype present in page source (view-source on any page)
- [ ] Run Lighthouse audit and confirm contrast warnings are resolved
- [ ] Visual check: light mode text still readable, dark rail pills still vibrant
- [ ] Mobile spot-check: font sizes comfortable in bright outdoor lighting

Closes #8

---
_Generated by [Claude Code](https://claude.ai/code/session_011pgYpGniNRCpHPt5NekkH3)_