### PR TITLE
fix: stale links, unstyled error pages, unauthenticated push endpoint

### DIFF
--- a/src/rail/views.ts
+++ b/src/rail/views.ts
@@ -98,11 +98,11 @@ export function aboutView(): string {
 <div class="about-section">
   <h2>Links</h2>
   <div class="about-links">
-    <a class="card" href="https://codeberg.org/clatis/pullcord" target="_blank" rel="noopener">
+    <a class="card" href="https://github.com/jakswa/pullcord" target="_blank" rel="noopener">
       <span class="ico">📦</span>
-      <div><div class="t">Source Code</div><div class="d">codeberg.org/clatis/pullcord</div></div>
+      <div><div class="t">Source Code</div><div class="d">github.com/jakswa/pullcord</div></div>
     </a>
-    <a class="card" href="https://codeberg.org/clatis/pullcord/issues" target="_blank" rel="noopener">
+    <a class="card" href="https://github.com/jakswa/pullcord/issues" target="_blank" rel="noopener">
       <span class="ico">💬</span>
       <div><div class="t">Issues &amp; Feedback</div><div class="d">Bug reports and feature requests</div></div>
     </a>

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { getRoutes, getRoute, searchStops, getStopsForRoute, getNearbyStops, getStop, getRouteDetail, getTripLookup, getRoutesForStop, getRoutesForStops, getRouteHeadsigns, getAllStopsWithRoutes, getTripStopSequences } from "../data/db.js";
 import { getVehicles, findArrivals, getStopArrivals } from "../data/realtime.js";
 import { getMockVehicles, getMockPredictions } from "../data/mock.js";
-import { getVapidPublicKey, registerCord, cancelCord, cordExists, getActiveCordCount, testFireAll } from "../data/push.js";
+import { getVapidPublicKey, registerCord, cancelCord, cordExists, getActiveCordCount } from "../data/push.js";
 import { getLatestSnapshot, getSystemTimeSeries, getLatestRouteSnapshots, getLatestRailSnapshots, getRouteTimeSeries } from "../data/metrics.js";
 
 const app = new Hono();
@@ -375,11 +375,6 @@ app.get("/push/status", (c) => {
   return c.json({ activeCords: getActiveCordCount() });
 });
 
-// POST /api/push/test — fire a test push to all active cords
-app.post("/push/test", async (c) => {
-  const sent = await testFireAll();
-  return c.json({ sent });
-});
 
 // ── Metrics ──
 

--- a/src/routes/bus.tsx
+++ b/src/routes/bus.tsx
@@ -71,11 +71,11 @@ app.get("/bus", async (c) => {
     if (!route) {
       return c.html(
         <Layout title="Route Not Found — Pullcord">
-          <div class="min-h-screen bg-gray-50 flex items-center justify-center">
-            <div class="text-center">
-              <h1 class="text-2xl font-bold text-gray-900 mb-4">Route Not Found</h1>
-              <p class="text-gray-600 mb-6">The route "{routeId}" could not be found.</p>
-              <a href="/" class="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700">
+          <div style="min-height:100vh;background:#f9fafb;display:flex;align-items:center;justify-content:center">
+            <div style="text-align:center;max-width:400px;margin:0 auto">
+              <h1 style="font-size:1.5rem;font-weight:bold;color:#111827;margin-bottom:1rem">Route Not Found</h1>
+              <p style="color:#6b7280;margin-bottom:1.5rem">The route "{routeId}" could not be found.</p>
+              <a href="/" style="display:inline-block;background:#2563eb;color:#fff;padding:0.75rem 1.5rem;border-radius:0.5rem;text-decoration:none">
                 ← Back to Home
               </a>
             </div>
@@ -87,11 +87,11 @@ app.get("/bus", async (c) => {
     if (!stop) {
       return c.html(
         <Layout title="Stop Not Found — Pullcord">
-          <div class="min-h-screen bg-gray-50 flex items-center justify-center">
-            <div class="text-center">
-              <h1 class="text-2xl font-bold text-gray-900 mb-4">Stop Not Found</h1>
-              <p class="text-gray-600 mb-6">The stop "{stopId}" could not be found.</p>
-              <a href="/" class="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700">
+          <div style="min-height:100vh;background:#f9fafb;display:flex;align-items:center;justify-content:center">
+            <div style="text-align:center;max-width:400px;margin:0 auto">
+              <h1 style="font-size:1.5rem;font-weight:bold;color:#111827;margin-bottom:1rem">Stop Not Found</h1>
+              <p style="color:#6b7280;margin-bottom:1.5rem">The stop "{stopId}" could not be found.</p>
+              <a href="/" style="display:inline-block;background:#2563eb;color:#fff;padding:0.75rem 1.5rem;border-radius:0.5rem;text-decoration:none">
                 ← Back to Home
               </a>
             </div>
@@ -158,11 +158,11 @@ app.get("/bus", async (c) => {
     
     return c.html(
       <Layout title="Error — Pullcord">
-        <div class="min-h-screen bg-gray-50 flex items-center justify-center">
-          <div class="text-center">
-            <h1 class="text-2xl font-bold text-gray-900 mb-4">Something went wrong</h1>
-            <p class="text-gray-600 mb-6">Unable to load the bus tracker. Please try again.</p>
-            <a href="/" class="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700">
+        <div style="min-height:100vh;background:#f9fafb;display:flex;align-items:center;justify-content:center">
+          <div style="text-align:center;max-width:400px;margin:0 auto">
+            <h1 style="font-size:1.5rem;font-weight:bold;color:#111827;margin-bottom:1rem">Something went wrong</h1>
+            <p style="color:#6b7280;margin-bottom:1.5rem">Unable to load the bus tracker. Please try again.</p>
+            <a href="/" style="display:inline-block;background:#2563eb;color:#fff;padding:0.75rem 1.5rem;border-radius:0.5rem;text-decoration:none">
               ← Back to Home
             </a>
           </div>

--- a/src/views/pages/About.tsx
+++ b/src/views/pages/About.tsx
@@ -188,14 +188,14 @@ export const AboutPage = () => (
       <section class="about-section">
         <h2 class="about-h2">Links</h2>
         <div class="about-links">
-          <a href="https://codeberg.org/clatis/pullcord" class="about-link-card" target="_blank" rel="noopener">
+          <a href="https://github.com/jakswa/pullcord" class="about-link-card" target="_blank" rel="noopener">
             <span class="about-link-icon">📦</span>
             <div>
               <div class="about-link-title">Source Code</div>
-              <div class="about-link-desc">codeberg.org/clatis/pullcord</div>
+              <div class="about-link-desc">github.com/jakswa/pullcord</div>
             </div>
           </a>
-          <a href="https://codeberg.org/clatis/pullcord/issues" class="about-link-card" target="_blank" rel="noopener">
+          <a href="https://github.com/jakswa/pullcord/issues" class="about-link-card" target="_blank" rel="noopener">
             <span class="about-link-icon">💬</span>
             <div>
               <div class="about-link-title">Issues &amp; Feedback</div>


### PR DESCRIPTION
## Summary

Three low-risk fixes found during a codebase audit:

- **Fix stale About page links** — Rail About page linked to `codeberg.org/clatis/pullcord` (defunct); updated to `github.com/jakswa/pullcord`. Closes #10

- **Fix unstyled bus error pages** — "Route Not Found", "Stop Not Found", and generic error pages in `bus.tsx` used Tailwind utility classes, but the CSS build only scans `public/` (not `src/`), so those classes were never compiled. Replaced with inline styles matching the existing pattern in `app.ts`. Closes #11

- **Remove unauthenticated `/api/push/test`** — `POST /api/push/test` fired push notifications to all active users with zero auth. Endpoint removed; `testFireAll()` remains available for local debugging. Closes #12

## Test plan

- [x] `bun test` — 39 tests pass
- [ ] Visit `/rail/about` and verify Source Code / Issues links point to GitHub
- [ ] Trigger a bus error page (e.g. `/bus?route=FAKE&stop=000000`) and verify it renders styled
- [ ] Confirm `POST /api/push/test` returns 404

https://claude.ai/code/session_01SC9mYTSgPJ8up68U5RDx45

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC9mYTSgPJ8up68U5RDx45)_