### PR TITLE
fix: XSS vulnerabilities in script tag injection

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -167,7 +167,7 @@ class PullcordApp {
       <div class="home-fav-card">
         <a href="${favLink}" class="home-fav-link">
           <div class="home-fav-name">${this.esc(fav.stopName)}</div>
-          <div class="home-fav-routes-inline">${fav.routes.join(' · ')}</div>
+          <div class="home-fav-routes-inline">${fav.routes.map(r => this.esc(r)).join(' · ')}</div>
         </a>
         <button class="home-fav-remove" data-stop="${this.esc(fav.stopId)}" aria-label="Remove favorite">✕</button>
       </div>
@@ -309,7 +309,7 @@ class PullcordApp {
         <div class="home-stop-info">
           <div class="home-stop-name">${this.esc(stop.stop_name)}</div>
           <div class="home-stop-meta">
-            <span class="home-stop-routes-inline">${stop.routes.join(' · ')}</span>
+            <span class="home-stop-routes-inline">${stop.routes.map(r => this.esc(r)).join(' · ')}</span>
             ${stop.distance ? `<span class="home-stop-distance">${Math.round(stop.distance)}m</span>` : ''}
           </div>
         </div>

--- a/src/routes/ride.tsx
+++ b/src/routes/ride.tsx
@@ -5,11 +5,19 @@ import { getRoute } from "../data/db.js";
 
 const app = new Hono();
 
+const SAFE_PARAM = /^[a-zA-Z0-9_.\-]{1,80}$/;
+
 // GET /ride?trip=TRIPID&stop=STOPID — ride view (track your position on a trip)
 app.get("/ride", (c) => {
   const tripId = c.req.query("trip");
   const stopId = c.req.query("stop"); // destination stop
   const routeId = c.req.query("route");
+
+  // Validate query params to prevent XSS via crafted URLs
+  if (tripId && !SAFE_PARAM.test(tripId)) return c.redirect("/");
+  if (stopId && !SAFE_PARAM.test(stopId)) return c.redirect("/");
+  if (routeId && !SAFE_PARAM.test(routeId)) return c.redirect("/");
+
   const publicRouteId = routeId ? (getRoute(routeId)?.route_short_name || routeId) : "";
 
   if (!tripId) return c.redirect("/");

--- a/src/views/pages/BusTracker.tsx
+++ b/src/views/pages/BusTracker.tsx
@@ -1,5 +1,10 @@
 import type { Route, Stop, RouteDetail } from "../../data/db.js";
 
+/** Safely serialize data for embedding in a <script> tag. Escapes '<' to prevent </script> injection. */
+function safeJsonForScript(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c');
+}
+
 export interface BusTrackerPageProps {
   route: Route | null;
   stop: Stop;
@@ -183,10 +188,10 @@ export const BusTrackerPage = (props: BusTrackerPageProps) => {
 
       {/* Data injection */}
       <script dangerouslySetInnerHTML={{ __html: multiRoute
-        ? `window.__INITIAL_DATA__ = ${JSON.stringify(initialData)};
-           window.__CONFIG__ = { stopId: '${stop.stop_id}', multiRoute: true, pollInterval: 30000 };`
-        : `window.__INITIAL_DATA__ = ${JSON.stringify(initialData)};
-           window.__CONFIG__ = { routeId: '${route!.route_short_name}', stopId: '${stop.stop_id}', routeShortName: '${route!.route_short_name}', pollInterval: 30000 };`
+        ? `window.__INITIAL_DATA__ = ${safeJsonForScript(initialData)};
+           window.__CONFIG__ = ${safeJsonForScript({ stopId: stop.stop_id, multiRoute: true, pollInterval: 30000 })};`
+        : `window.__INITIAL_DATA__ = ${safeJsonForScript(initialData)};
+           window.__CONFIG__ = ${safeJsonForScript({ routeId: route!.route_short_name, stopId: stop.stop_id, routeShortName: route!.route_short_name, pollInterval: 30000 })};`
       }} />
     </div>
   );

--- a/src/views/pages/Ride.tsx
+++ b/src/views/pages/Ride.tsx
@@ -1,3 +1,8 @@
+/** Safely serialize data for embedding in a <script> tag. Escapes '<' to prevent </script> injection. */
+function safeJsonForScript(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c');
+}
+
 export const RidePage = ({ tripId, stopId, routeId }: { tripId: string; stopId: string; routeId: string }) => (
   <div class="ride-shell">
     {/* Header */}
@@ -38,7 +43,7 @@ export const RidePage = ({ tripId, stopId, routeId }: { tripId: string; stopId: 
 
     {/* Config passed to JS */}
     <script dangerouslySetInnerHTML={{ __html: `
-      window.__RIDE_CONFIG__ = ${JSON.stringify({ tripId, stopId, routeId })};
+      window.__RIDE_CONFIG__ = ${safeJsonForScript({ tripId, stopId, routeId })};
     ` }} />
     <script src="/public/ride.js"></script>
   </div>


### PR DESCRIPTION
## Summary

Fixes three XSS vectors where data was injected into `<script>` blocks without proper escaping.

- **Ride page `</script>` injection (CRITICAL)** — query params (`trip`, `stop`, `route`) were passed to `JSON.stringify` inside a `<script>` tag with zero validation. `JSON.stringify` doesn't escape `</script>`, so a crafted URL could inject arbitrary JS. Fixed by: (1) validating params against `/^[a-zA-Z0-9_.\-]{1,80}$/`, (2) escaping `<` as `<` via `safeJsonForScript()`.

- **BusTracker unescaped string interpolation (HIGH)** — `route_short_name` and `stop_id` were injected via manual `'${value}'` template strings (not `JSON.stringify`) inside a script block. Replaced with `safeJsonForScript()` for all embedded data.

- **Client-side route name innerHTML (LOW)** — `routes.join(' · ')` was injected into innerHTML without HTML-escaping. Now passes each route through `esc()` before joining.

Closes #14

## Test plan

- [x] `bun test` — 27 tests pass (1 pre-existing failure unrelated)
- [ ] Craft malicious URL `/ride?trip=</script><script>alert(1)//&stop=x&route=x` and verify redirect to `/`
- [ ] Verify bus tracker page still loads normally with valid route/stop
- [ ] Verify favorites and search results render route names correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_013QubKF5ZneJp2QQzDKfC6V)_