### PR TITLE
fix: timezone bug in adherence calc, fetch timeout, API key leak

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -225,9 +225,10 @@ app.get("/health/diag", async (c) => {
       : Math.round((matched / withTripAndPosition.length) * 1000) / 1000;
   } catch (err: any) {
     diag.apiReachable = false;
-    diag.error = err?.name === "AbortError"
+    const rawMsg = err?.name === "AbortError"
       ? "Request timed out after 5000ms"
       : (err?.message || String(err));
+    diag.error = rawMsg.replace(/apiKey=[^&\s]+/g, 'apiKey=***');
   }
 
   return c.json(diag);

--- a/src/data/realtime.ts
+++ b/src/data/realtime.ts
@@ -88,18 +88,24 @@ class RealtimeDataService {
   }
 
   private async fetchProtobufData(url: string): Promise<any[]> {
-    const response = await fetch(`${url}?apiKey=${this.apiKey}`);
-    
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} ${response.statusText} from ${url.split('?')[0]}`);
-    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    try {
+      const response = await fetch(`${url}?apiKey=${this.apiKey}`, { signal: controller.signal });
 
-    const buffer = await response.arrayBuffer();
-    const protoRoot = await this.loadProtoDefinitions();
-    const FeedMessage = protoRoot.lookupType("transit_realtime.FeedMessage");
-    const message = FeedMessage.decode(new Uint8Array(buffer));
-    
-    return message.entity || [];
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText} from ${url.split('?')[0]}`);
+      }
+
+      const buffer = await response.arrayBuffer();
+      const protoRoot = await this.loadProtoDefinitions();
+      const FeedMessage = protoRoot.lookupType("transit_realtime.FeedMessage");
+      const message = FeedMessage.decode(new Uint8Array(buffer));
+
+      return message.entity || [];
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   private isCacheValid<T>(cache: CachedData<T> | null): boolean {
@@ -269,9 +275,11 @@ function computeAdherenceSec(rtArrivalSec: number, scheduledTimeStr: string): nu
   const [h, m, s] = [parts[0], parts[1], parts[2] || 0];
   const schedTotalSec = h * 3600 + m * 60 + s;
 
-  // Determine service midnight from the RT arrival date
+  // Determine service midnight from the RT arrival date in Eastern time
+  // (GTFS schedule times are in America/New_York; server may be UTC on Fly.io)
   const rtDate = new Date(rtArrivalSec * 1000);
-  const todayMidnightSec = new Date(rtDate.getFullYear(), rtDate.getMonth(), rtDate.getDate()).getTime() / 1000;
+  const etNow = new Date(rtDate.toLocaleString("en-US", { timeZone: "America/New_York" }));
+  const todayMidnightSec = new Date(etNow.getFullYear(), etNow.getMonth(), etNow.getDate()).getTime() / 1000;
 
   // GTFS times >= 24:00:00 mean the service day started yesterday
   const serviceMidnightSec = h >= 24 ? todayMidnightSec - 86400 : todayMidnightSec;


### PR DESCRIPTION
## Summary

Three fixes in the realtime data pipeline:

- **Timezone bug in `computeAdherenceSec`** — computed midnight using server's local timezone (UTC on Fly.io) instead of America/New_York, causing a 4-5 hour offset in all schedule adherence calculations. Fixed by converting to ET before computing midnight, matching the pattern already used in `metrics.ts`.

- **No fetch timeout on MARTA API calls** — `fetchProtobufData` called `fetch()` with no timeout, so a MARTA API hang would block the app indefinitely. Added 15s `AbortController` timeout with proper `clearTimeout` in `finally`.

- **API key leak via `/health/diag`** — error messages from failed fetches could contain the full URL including the API key, exposed to any unauthenticated caller. Now sanitizes with `apiKey=***`.

Closes #15, closes #16

## Test plan

- [x] `bun test` — 27 tests pass (1 pre-existing failure unrelated)
- [ ] Deploy and verify adherence values look reasonable (not null/wrong)
- [ ] Hit `/health/diag` during MARTA downtime and confirm no API key in response
- [ ] Verify app recovers within 15s when MARTA API is unresponsive

---
_Generated by [Claude Code](https://claude.ai/code/session_013QubKF5ZneJp2QQzDKfC6V)_