### PR TITLE
fix: explore map dark mode tiles and ride route badge visibility

### DIFF
--- a/public/explore.js
+++ b/public/explore.js
@@ -30,8 +30,12 @@
       attributionControl: false,
     });
 
-    // Tile layer — CartoDB Positron for clean look
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    // Adaptive map tiles — dark for dark mode, light positron for light mode
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const tileUrl = prefersDark
+      ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
+      : 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
+    L.tileLayer(tileUrl, {
       maxZoom: MAX_ZOOM,
       subdomains: 'abcd',
     }).addTo(map);

--- a/public/ride.js
+++ b/public/ride.js
@@ -62,7 +62,7 @@
             const badge = document.getElementById('ride-route-badge');
             if (badge) {
               badge.textContent = routeShortName;
-              badge.style.display = '';
+              badge.style.display = 'inline-flex';
             }
           }
           if (rData.route?.route_color) {


### PR DESCRIPTION
## Summary

Two UI bug fixes:

- **Explore map ignores dark mode** — tile layer hardcoded `light_all` CartoDB tiles while `app.js` and `ride.js` both correctly detect `prefers-color-scheme: dark`. Added the same `matchMedia` check to `explore.js` so dark mode users get `dark_all` tiles.

- **Ride route badge permanently hidden** — CSS sets `.ride-route-badge { display: none }` and the JS reset `badge.style.display = ''` just falls back to the CSS `none`. Changed to `display = 'inline-flex'` to explicitly override.

Closes #17

## Test plan

- [x] `bun test` — 27 tests pass (1 pre-existing failure unrelated)
- [ ] Toggle system dark mode and verify explore map uses dark tiles
- [ ] Open a ride view and verify the route badge is visible

---
_Generated by [Claude Code](https://claude.ai/code/session_013QubKF5ZneJp2QQzDKfC6V)_