### PR TITLE
fix: push cord retry on transient failure + stale-while-revalidate dedup

### DIFF
--- a/src/data/push.ts
+++ b/src/data/push.ts
@@ -236,12 +236,13 @@ async function checkCords(
           },
         );
         console.log(`🔔 Push sent for cord ${cord.id}`);
+        stmtDeleteById.run(cord.id);
       } catch (err: any) {
         console.error(`Push failed for cord ${cord.id}:`, err.statusCode || err.message);
+        if (err.statusCode === 410 || err.statusCode === 404) {
+          stmtDeleteById.run(cord.id);
+        }
       }
-
-      // Cord served its purpose — delete immediately
-      stmtDeleteById.run(cord.id);
     }
   }
 }

--- a/src/data/realtime.ts
+++ b/src/data/realtime.ts
@@ -128,12 +128,14 @@ class RealtimeDataService {
     }
 
     // Stale-while-revalidate: serve stale, refresh in background
-    if (this.isCacheServable(this.vehicleCache) && !this.vehicleFetching) {
-      this.vehicleFetching = true;
-      this.fetchProtobufData(VEHICLE_POSITIONS_URL).then(entities => {
-        this.vehicleCache = { data: entities, timestamp: Date.now() };
-        this.vehicleFetching = false;
-      }).catch((err) => { console.error('❌ Vehicle position fetch failed:', err.message || err); this.vehicleFetching = false; });
+    if (this.isCacheServable(this.vehicleCache)) {
+      if (!this.vehicleFetching) {
+        this.vehicleFetching = true;
+        this.fetchProtobufData(VEHICLE_POSITIONS_URL).then(entities => {
+          this.vehicleCache = { data: entities, timestamp: Date.now() };
+          this.vehicleFetching = false;
+        }).catch((err) => { console.error('❌ Vehicle position fetch failed:', err.message || err); this.vehicleFetching = false; });
+      }
       return this.vehicleCache!.data;
     }
 
@@ -148,12 +150,14 @@ class RealtimeDataService {
     }
 
     // Stale-while-revalidate: serve stale, refresh in background
-    if (this.isCacheServable(this.tripUpdatesCache) && !this.tripUpdatesFetching) {
-      this.tripUpdatesFetching = true;
-      this.fetchProtobufData(TRIP_UPDATES_URL).then(entities => {
-        this.tripUpdatesCache = { data: entities, timestamp: Date.now() };
-        this.tripUpdatesFetching = false;
-      }).catch((err) => { console.error('❌ Trip updates fetch failed:', err.message || err); this.tripUpdatesFetching = false; });
+    if (this.isCacheServable(this.tripUpdatesCache)) {
+      if (!this.tripUpdatesFetching) {
+        this.tripUpdatesFetching = true;
+        this.fetchProtobufData(TRIP_UPDATES_URL).then(entities => {
+          this.tripUpdatesCache = { data: entities, timestamp: Date.now() };
+          this.tripUpdatesFetching = false;
+        }).catch((err) => { console.error('❌ Trip updates fetch failed:', err.message || err); this.tripUpdatesFetching = false; });
+      }
       return this.tripUpdatesCache!.data;
     }
 


### PR DESCRIPTION
## Summary

Two reliability fixes in the data pipeline:

- **Push cord deleted on transient send failure (#21)** — `checkCords()` unconditionally deleted the cord after attempting `webpush.sendNotification()`, even if the send failed due to a transient error (network timeout, rate limit). Users would silently miss their bus notification. Now the cord is only deleted on success or unrecoverable errors (410/404); transient failures leave the cord alive for retry on the next 30s poll cycle.

- **Stale-while-revalidate redundant fetch (#22)** — `getVehiclePositions()` and `getTripUpdates()` would fall through to a blocking synchronous fetch when a background refresh was already in-flight, defeating the stale-while-revalidate pattern and multiplying MARTA API calls under concurrent load. Now serves stale cache data when a refresh is already in progress.

Closes #21, closes #22

## Test plan

- [x] `bun test` — 39 tests pass
- [ ] Register a cord, simulate push failure (invalid subscription), verify cord survives for retry
- [ ] Under concurrent load, verify only one background fetch per stale window (no redundant MARTA API calls)
- [ ] Verify cold-start (no cache) still blocks until first fetch completes

https://claude.ai/code/session_016YhkiVvxWfFQ5uzv9jaCXR

---
_Generated by [Claude Code](https://claude.ai/code/session_016YhkiVvxWfFQ5uzv9jaCXR)_