### PR TITLE
fix: polyline leak, geolocation crash, unescaped rail HTML

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1163,15 +1163,15 @@ class PullcordApp {
     const isScheduled = !pred.isRealtime;
     const opacity = isScheduled ? 'opacity:0.45' : '';
     const timePrefix = isScheduled ? '~' : '';
-    const href = pred.trainId ? `/rail/train/${pred.trainId}` : '#';
+    const href = pred.trainId ? `/rail/train/${this.esc(pred.trainId)}` : '#';
 
     const timeText = minutes < 1 ? 'NOW' : `${timePrefix}${minutes} min`;
     return `
       <a class="d-upcoming-row d-rail-row" style="--row-color:${color};${opacity}" href="${href}">
         <div class="d-upcoming-info">
           <div class="d-upcoming-headsign">
-            <span class="d-rail-dir">${pred.direction}</span>
-            <span class="d-rail-line" style="background:${color}">${pred.line.toLowerCase()}</span>
+            <span class="d-rail-dir">${this.esc(pred.direction)}</span>
+            <span class="d-rail-line" style="background:${color}">${this.esc(pred.line).toLowerCase()}</span>
             ${this.esc(pred.headsign || '')}
           </div>
         </div>
@@ -1585,10 +1585,11 @@ class PullcordApp {
     Object.values(shapes).forEach(coords => {
       if (coords.length === 0) return;
       // Outline
-      L.polyline(coords, {
+      const outline = L.polyline(coords, {
         color: '#1e293b', weight: 8, opacity: 0.8,
         lineCap: 'round', lineJoin: 'round'
       }).addTo(this.map);
+      this.routePolylines.push(outline);
       // Route color
       const poly = L.polyline(coords, {
         color: this.routeColor, weight: 4, opacity: 0.9,

--- a/public/explore.js
+++ b/public/explore.js
@@ -304,6 +304,11 @@
   // ─── Geolocation ───
 
   function locateUser() {
+    if (!navigator.geolocation) {
+      const btn = document.getElementById('explore-locate-btn');
+      if (btn) btn.classList.remove('explore-locating');
+      return;
+    }
     const btn = document.getElementById('explore-locate-btn');
     if (btn) btn.classList.add('explore-locating');
 


### PR DESCRIPTION
## Summary

Three client-side bug fixes:

- **Polyline outline leak on route switch** — `drawRouteShapes()` created outline polylines but never tracked them in `this.routePolylines`, so `clearMapRoute()` left them as orphaned Leaflet layers. Now tracked and properly cleaned up.

- **Geolocation crash in explore.js** — `locateUser()` called `navigator.geolocation.getCurrentPosition()` without checking if geolocation exists. Added the same guard that `app.js` and `ride.js` already have.

- **Unescaped HTML in rail rendering** — `pred.trainId`, `pred.direction`, and `pred.line` were inserted into innerHTML without `esc()`, unlike `pred.headsign` which was properly escaped. Now all values go through `this.esc()`.

Closes #25

## Test plan

- [x] `bun test` — 39 tests pass
- [ ] Switch routes on bus tracker map; verify no stale dark outlines remain
- [ ] Open explore page in a browser without geolocation; verify no JS error
- [ ] Inspect rail arrivals HTML; verify all dynamic values are escaped

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWVH9FWmZxUnohcmrd6NKc)_