### PR TITLE
fix: harden API input validation

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -11,6 +11,7 @@ const app = new Hono();
 
 const ROUTE_ID_RE = /^[a-zA-Z0-9_-]{1,20}$/;
 const STOP_ID_RE = /^[a-zA-Z0-9]{1,20}$/;
+const TRIP_ID_RE = /^[a-zA-Z0-9_.\-]{1,120}$/;
 
 function validRouteId(id: string): boolean {
   return ROUTE_ID_RE.test(id);
@@ -56,7 +57,8 @@ app.get("/stops", (c) => {
     const rawQuery = c.req.query("q");
     const lat = c.req.query("lat");
     const lon = c.req.query("lon");
-    const radius = parseInt(c.req.query("radius") || "500");
+    const rawRadius = parseInt(c.req.query("radius") || "500");
+    const radius = isNaN(rawRadius) ? 500 : Math.max(50, Math.min(5000, rawRadius));
     const limit = clampLimit(c.req.query("limit"));
 
     if (rawQuery) {
@@ -296,6 +298,7 @@ app.get("/stops/:stopId/arrivals", async (c) => {
 app.get("/trip/:tripId/stops", (c) => {
   try {
     const tripId = c.req.param("tripId");
+    if (!TRIP_ID_RE.test(tripId)) return c.json({ error: "Invalid tripId" }, 400);
     const sequences = getTripStopSequences([tripId]);
     const stops = sequences.get(tripId);
     if (!stops || stops.length === 0) {
@@ -331,11 +334,24 @@ app.get("/push/vapid", (c) => {
 // POST /api/push/cord — register a cord (subscribe to push for a bus)
 app.post("/push/cord", async (c) => {
   try {
-    const body = await c.req.json();
+    let body: any;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
     const { subscription, routeId, stopId, vehicleId, tripId, directionId, thresholdMinutes } = body;
 
     if (!subscription?.endpoint || !subscription?.keys?.p256dh || !subscription?.keys?.auth) {
       return c.json({ error: "Invalid push subscription" }, 400);
+    }
+    try {
+      const endpointUrl = new URL(subscription.endpoint);
+      if (endpointUrl.protocol !== "https:") {
+        return c.json({ error: "Push endpoint must use HTTPS" }, 400);
+      }
+    } catch {
+      return c.json({ error: "Invalid push endpoint URL" }, 400);
     }
     if (!routeId || !stopId) {
       return c.json({ error: "routeId and stopId required" }, 400);
@@ -387,7 +403,9 @@ app.get("/metrics/snapshot", (c) => {
 
 // GET /api/metrics/system?hours=24 — system-level time series
 app.get("/metrics/system", (c) => {
-  const hours = Math.min(168, Math.max(1, parseInt(c.req.query("hours") || "24")));
+  const parsed = parseInt(c.req.query("hours") || "24");
+  if (isNaN(parsed)) return c.json({ error: "Invalid 'hours' parameter" }, 400);
+  const hours = Math.min(168, Math.max(1, parsed));
   return c.json(getSystemTimeSeries(hours));
 });
 
@@ -405,7 +423,9 @@ app.get("/metrics/rail", (c) => {
 app.get("/metrics/route/:routeId", (c) => {
   const routeId = c.req.param("routeId");
   if (!ROUTE_ID_RE.test(routeId)) return c.json({ error: "Invalid routeId" }, 400);
-  const hours = Math.min(168, Math.max(1, parseInt(c.req.query("hours") || "24")));
+  const parsed = parseInt(c.req.query("hours") || "24");
+  if (isNaN(parsed)) return c.json({ error: "Invalid 'hours' parameter" }, 400);
+  const hours = Math.min(168, Math.max(1, parsed));
   return c.json(getRouteTimeSeries(routeId, hours));
 });
 


### PR DESCRIPTION
## Summary

Five input validation hardening fixes in the API layer:

- **Radius clamping** — `GET /api/stops?radius=` now clamped to 50-5000m with NaN fallback to 500, preventing full table scans and silent NaN propagation
- **Hours NaN guard** — `GET /api/metrics/system?hours=` and `/metrics/route/:routeId?hours=` now return 400 for non-numeric values instead of silently returning empty arrays
- **TripId validation** — `GET /api/trip/:tripId/stops` now validates against `/^[a-zA-Z0-9_.\-]{1,120}$/`, matching the validation pattern used for all other route params
- **JSON parse error handling** — `POST /api/push/cord` now returns 400 for malformed JSON instead of 500
- **Push endpoint SSRF** — `subscription.endpoint` now validated as a parseable HTTPS URL before being stored and later POSTed to by `web-push`

Closes #26

## Test plan

- [x] `bun test` — 39 tests pass
- [ ] `curl '/api/stops?lat=33.75&lon=-84.39&radius=abc'` → uses default 500m, not NaN
- [ ] `curl '/api/metrics/system?hours=abc'` → 400 error
- [ ] `curl '/api/trip/../../etc/passwd/stops'` → 400 error
- [ ] `curl -X POST /api/push/cord -d 'not json'` → 400 error
- [ ] `curl -X POST /api/push/cord` with `endpoint: "http://internal"` → 400 error

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWVH9FWmZxUnohcmrd6NKc)_