### PR TITLE
fix: resolve 23 TypeScript errors and add CI type checking

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
+      - run: bun run typecheck
       - run: bun test
 
   deploy:

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "dev:css": "bun x @tailwindcss/cli -i src/styles/app.css -o public/styles.css --watch",
     "dev": "bun run build:css && bun run --hot src/index.ts",
     "start": "bun run build:css && bun run src/index.ts",
-    "test": "bun test"
+    "test": "bun test",
+    "typecheck": "bunx tsc --noEmit"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "1.3.9",
     "playwright": "^1.58.2"
   },
   "peerDependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -198,7 +198,7 @@ app.get("/health/diag", async (c) => {
     const FeedMessage = protoRoot.lookupType("transit_realtime.FeedMessage");
 
     const buffer = await response.arrayBuffer();
-    const message = FeedMessage.decode(new Uint8Array(buffer));
+    const message = FeedMessage.decode(new Uint8Array(buffer)) as any;
     const entities: any[] = message.entity || [];
 
     diag.rawEntities = entities.length;

--- a/src/data/gtfs-import.ts
+++ b/src/data/gtfs-import.ts
@@ -172,7 +172,7 @@ export class GTFSImporter {
 
     const tx = this.db.transaction(() => {
       for (const record of records) {
-        stmt.run(...Object.values(record));
+        stmt.run(...(Object.values(record) as [string]));
       }
     });
     tx();
@@ -206,7 +206,7 @@ export class GTFSImporter {
           );
         }
         for (const record of chunk) {
-          stmt!.run(...Object.values(record));
+          stmt!.run(...(Object.values(record) as [string]));
         }
         totalCount += chunk.length;
         chunk = [];
@@ -271,7 +271,7 @@ export class GTFSImporter {
     );
     const tx = this.db.transaction(() => {
       for (const record of records) {
-        stmt.run(...Object.values(record));
+        stmt.run(...(Object.values(record) as [string]));
       }
       // group_id = MIN(stop_id) per stop_name — groups directional stops at same location
       this.db.run(`
@@ -435,8 +435,8 @@ export class GTFSImporter {
     if (tripIds.length === 0) {
       console.log('No expired trips to clean');
       // Still clean calendar entries even if no trips
-      this.db.run(`DELETE FROM calendar WHERE end_date < ?`, today);
-      this.db.run(`DELETE FROM calendar_dates WHERE service_id IN (${placeholders})`, ...ids);
+      this.db.run(`DELETE FROM calendar WHERE end_date < ?`, [today]);
+      this.db.run(`DELETE FROM calendar_dates WHERE service_id IN (${placeholders})`, ids);
       return;
     }
 
@@ -446,21 +446,21 @@ export class GTFSImporter {
       for (let i = 0; i < tripIds.length; i += 500) {
         const chunk = tripIds.slice(i, i + 500);
         const ph = chunk.map(() => '?').join(',');
-        this.db.run(`DELETE FROM stop_times WHERE trip_id IN (${ph})`, ...chunk);
+        this.db.run(`DELETE FROM stop_times WHERE trip_id IN (${ph})`, chunk);
       }
 
       // Delete trips
-      this.db.run(`DELETE FROM trips WHERE service_id IN (${placeholders})`, ...ids);
+      this.db.run(`DELETE FROM trips WHERE service_id IN (${placeholders})`, ids);
 
       // Delete expired calendar entries
-      this.db.run(`DELETE FROM calendar WHERE end_date < ?`, today);
-      this.db.run(`DELETE FROM calendar_dates WHERE service_id IN (${placeholders})`, ...ids);
+      this.db.run(`DELETE FROM calendar WHERE end_date < ?`, [today]);
+      this.db.run(`DELETE FROM calendar_dates WHERE service_id IN (${placeholders})`, ids);
 
       // Shapes: only delete if no remaining trips reference them
       for (const shapeId of shapeIds) {
         const remaining = this.db.prepare('SELECT 1 FROM trips WHERE shape_id = ? LIMIT 1').get(shapeId);
         if (!remaining) {
-          this.db.run('DELETE FROM shapes WHERE shape_id = ?', shapeId);
+          this.db.run('DELETE FROM shapes WHERE shape_id = ?', [shapeId]);
         }
       }
     });

--- a/src/data/metrics.ts
+++ b/src/data/metrics.ts
@@ -326,37 +326,39 @@ interface RailSample {
   scheduledCount: number;
 }
 
-async function sampleRailMetrics(): Promise<RailSample[]> {
-  let arrivals;
-  try {
-    arrivals = await fetchRailArrivals();
-  } catch {
-    return [];
-  }
-
-  const byLine = new Map<string, { trains: Set<string>; totalWait: number; count: number; realtime: number; scheduled: number }>();
-
-  for (const a of arrivals) {
-    let line = byLine.get(a.line);
-    if (!line) {
-      line = { trains: new Set(), totalWait: 0, count: 0, realtime: 0, scheduled: 0 };
-      byLine.set(a.line, line);
-    }
-    line.trains.add(a.trainId);
-    line.totalWait += a.waitSeconds;
-    line.count++;
-    if (a.isRealtime) line.realtime++;
-    else line.scheduled++;
-  }
-
-  return Array.from(byLine.entries()).map(([lineName, data]) => ({
-    line: lineName,
-    trains: data.trains.size,
-    avgDelaySec: data.count > 0 ? data.totalWait / data.count : 0,
-    realtimeCount: data.realtime,
-    scheduledCount: data.scheduled,
-  }));
-}
+// Rail sampling paused — sampleRailMetrics commented out because fetchRailArrivals
+// import is disabled (no good KPI yet). Re-enable when we find one.
+// async function sampleRailMetrics(): Promise<RailSample[]> {
+//   let arrivals;
+//   try {
+//     arrivals = await fetchRailArrivals();
+//   } catch {
+//     return [];
+//   }
+//
+//   const byLine = new Map<string, { trains: Set<string>; totalWait: number; count: number; realtime: number; scheduled: number }>();
+//
+//   for (const a of arrivals) {
+//     let line = byLine.get(a.line);
+//     if (!line) {
+//       line = { trains: new Set(), totalWait: 0, count: 0, realtime: 0, scheduled: 0 };
+//       byLine.set(a.line, line);
+//     }
+//     line.trains.add(a.trainId);
+//     line.totalWait += a.waitSeconds;
+//     line.count++;
+//     if (a.isRealtime) line.realtime++;
+//     else line.scheduled++;
+//   }
+//
+//   return Array.from(byLine.entries()).map(([lineName, data]) => ({
+//     line: lineName,
+//     trains: data.trains.size,
+//     avgDelaySec: data.count > 0 ? data.totalWait / data.count : 0,
+//     realtimeCount: data.realtime,
+//     scheduledCount: data.scheduled,
+//   }));
+// }
 
 // ─── Collection orchestrator ───
 
@@ -452,7 +454,7 @@ export function cleanOldMetrics(): void {
   const cutoff = Math.floor(Date.now() / 1000) - RETENTION_DAYS * 86400;
   try {
     const db = getDb();
-    const result = db.run(`DELETE FROM metrics WHERE ts < ?`, cutoff);
+    const result = db.run(`DELETE FROM metrics WHERE ts < ?`, [cutoff]);
     if (result.changes > 0) {
       console.log(`📊 Metrics cleanup: removed ${result.changes} old rows`);
     }

--- a/src/data/realtime.ts
+++ b/src/data/realtime.ts
@@ -411,7 +411,7 @@ async function findArrivals(opts: FindArrivalsOptions): Promise<ArrivalPredictio
       .filter(v => v.tripId && v.vehicleId)
       .map(v => v.tripId);
     const tripStopSeqs = allVehicleTripIds.length > 0
-      ? getTripStopSequences(allVehicleTripIds) : new Map();
+      ? getTripStopSequences(allVehicleTripIds) : new Map<string, Array<{ stop_id: string; lat: number; lon: number; sequence: number; arrival_time: string }>>();
 
     for (const veh of vehicles) {
       if (!veh.tripId || !veh.vehicleId) continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ if (startupPromotion.promoted) {
 }
 
 const dbPath = resolveScheduleDbPath();
-console.log(`📊 Database: ${Bun.file(dbPath).exists() ? "✓ Found" : "❌ Missing"} (${dbPath})`);
+console.log(`📊 Database: ${await Bun.file(dbPath).exists() ? "✓ Found" : "❌ Missing"} (${dbPath})`);
 
 runMigrations(); // throws on failure → process crashes → no server bind → deploy fails
 

--- a/src/routes/rail.tsx
+++ b/src/routes/rail.tsx
@@ -9,13 +9,15 @@ import {
   RailTrainTimeline,
 } from "../views/pages/Rail.js";
 
-const app = new Hono();
+type Env = { Variables: { isRailHost: boolean } };
+
+const app = new Hono<Env>();
 
 // GET /rail — landing page (all stations)
 app.get("/rail", async (c) => {
   const arrivals = await fetchArrivals();
   const partial = c.req.query("partial");
-  const isRailHost = c.get("isRailHost" as any) || false;
+  const isRailHost = c.get("isRailHost") || false;
 
   if (partial === "1") {
     return c.html(<RailStationList arrivals={arrivals} />);
@@ -29,7 +31,7 @@ app.get("/rail/train/:trainId", async (c) => {
   const trainId = c.req.param("trainId");
   const arrivals = await fetchArrivals();
   const partial = c.req.query("partial");
-  const isRailHost = c.get("isRailHost" as any) || false;
+  const isRailHost = c.get("isRailHost") || false;
 
   if (partial === "1") {
     return c.html(<RailTrainTimeline trainId={trainId} arrivals={arrivals} />);
@@ -44,7 +46,7 @@ app.get("/rail/train/:trainId", async (c) => {
 app.get("/rail/:slug", async (c) => {
   const slug = c.req.param("slug");
   const arrivals = await fetchArrivals();
-  const isRailHost = c.get("isRailHost" as any) || false;
+  const isRailHost = c.get("isRailHost") || false;
 
   // Find matching station
   const stationArrivals = arrivals.filter(

--- a/src/types/web-push.d.ts
+++ b/src/types/web-push.d.ts
@@ -1,0 +1,1 @@
+declare module 'web-push';


### PR DESCRIPTION
## Summary

- **Fix 23 TypeScript errors** across 7 files — including a real bug where `Bun.file().exists()` (returns `Promise<boolean>`) was used in a ternary without `await`, always evaluating as truthy
- **Add CI type checking** — `bun run typecheck` step in the deploy workflow catches type errors before they ship
- **Pin `@types/bun`** from `"latest"` to `"1.3.9"` for reproducible builds

Closes #24

## Error breakdown

| File | Errors | Fix |
|------|--------|-----|
| `src/index.ts` | 1 | `await` the `Bun.file().exists()` Promise (real bug) |
| `src/data/gtfs-import.ts` | 9 | SQLQueryBindings array wrapping |
| `src/routes/rail.tsx` | 7 | Hono `Env` type parameterization |
| `src/data/metrics.ts` | 2 | Dead `fetchRailArrivals` ref + bind param |
| `src/data/realtime.ts` | 2 | Explicit type params for Map |
| `src/app.ts` | 1 | Cast protobuf decode result |
| `src/data/push.ts` | 1 | `web-push` module declaration |

## Test plan

- [x] `bun test` — 39 tests pass
- [x] `bunx tsc --noEmit` — 0 errors (was 23)
- [ ] CI runs typecheck step on PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWVH9FWmZxUnohcmrd6NKc)_