### PR TITLE
fix: schedule adherence always null on UTC servers

### DIFF
--- a/src/data/eta.ts
+++ b/src/data/eta.ts
@@ -114,3 +114,33 @@ export function computeETA(
 
   return { eta: Math.max(0, Math.round(eta)), atTerminal: false };
 }
+
+/**
+ * Compute schedule adherence: positive = late, negative = early.
+ * Returns null if the delta exceeds ±30 min (likely a data edge case).
+ *
+ * Works correctly regardless of the server's local timezone by deriving
+ * midnight-ET as a Unix timestamp from the ET time-of-day components.
+ */
+export function computeAdherenceSec(rtArrivalSec: number, scheduledTimeStr: string): number | null {
+  const parts = scheduledTimeStr.split(':').map(Number);
+  if (parts.length < 2) return null;
+  const [h, m, s] = [parts[0], parts[1], parts[2] || 0];
+  const schedTotalSec = h * 3600 + m * 60 + s;
+
+  // Determine service midnight from the RT arrival date in Eastern time
+  // (GTFS schedule times are in America/New_York; server may be UTC on Fly.io)
+  const rtDate = new Date(rtArrivalSec * 1000);
+  const etNow = new Date(rtDate.toLocaleString("en-US", { timeZone: "America/New_York" }));
+  const elapsedSinceETMidnight = etNow.getHours() * 3600 + etNow.getMinutes() * 60 + etNow.getSeconds();
+  const todayMidnightSec = rtArrivalSec - elapsedSinceETMidnight;
+
+  // GTFS times >= 24:00:00 mean the service day started yesterday
+  const serviceMidnightSec = h >= 24 ? todayMidnightSec - 86400 : todayMidnightSec;
+  const scheduledSec = serviceMidnightSec + schedTotalSec;
+  const delta = Math.round(rtArrivalSec - scheduledSec);
+
+  // Cap at ±30 min — anything beyond is likely a data edge case
+  if (Math.abs(delta) > 1800) return null;
+  return delta;
+}

--- a/src/data/realtime.ts
+++ b/src/data/realtime.ts
@@ -1,7 +1,7 @@
 import { load } from "protobufjs";
 import path from "path";
 import { getScheduledArrivals, getStopIdsByName, getTripStopSequences, type Trip } from "./db";
-import { computeETA, parseTimeToSec, type TripStop } from "./eta";
+import { computeETA, parseTimeToSec, computeAdherenceSec, type TripStop } from "./eta";
 const VEHICLE_POSITIONS_URL = "https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/vehicle/vehiclepositions.pb";
 const TRIP_UPDATES_URL = "https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/tripupdate/tripupdates.pb";
 const CACHE_DURATION = 30 * 1000; // 30 seconds
@@ -270,30 +270,6 @@ class RealtimeDataService {
 // Single function for all prediction paths — single-route, multi-route, with or without tiers.
 // Handles: paired stops, ETA, staleness, adherence, dedup, tier classification.
 // ─────────────────────────────────────
-
-// Compute schedule adherence: positive = late, negative = early
-// Returns null if delta is unreasonable (>30 min, likely midnight edge case)
-function computeAdherenceSec(rtArrivalSec: number, scheduledTimeStr: string): number | null {
-  const parts = scheduledTimeStr.split(':').map(Number);
-  if (parts.length < 2) return null;
-  const [h, m, s] = [parts[0], parts[1], parts[2] || 0];
-  const schedTotalSec = h * 3600 + m * 60 + s;
-
-  // Determine service midnight from the RT arrival date in Eastern time
-  // (GTFS schedule times are in America/New_York; server may be UTC on Fly.io)
-  const rtDate = new Date(rtArrivalSec * 1000);
-  const etNow = new Date(rtDate.toLocaleString("en-US", { timeZone: "America/New_York" }));
-  const todayMidnightSec = new Date(etNow.getFullYear(), etNow.getMonth(), etNow.getDate()).getTime() / 1000;
-
-  // GTFS times >= 24:00:00 mean the service day started yesterday
-  const serviceMidnightSec = h >= 24 ? todayMidnightSec - 86400 : todayMidnightSec;
-  const scheduledSec = serviceMidnightSec + schedTotalSec;
-  const delta = Math.round(rtArrivalSec - scheduledSec);
-
-  // Cap at ±30 min — anything beyond is likely a data edge case
-  if (Math.abs(delta) > 1800) return null;
-  return delta;
-}
 
 // Singleton instance
 const realtimeService = new RealtimeDataService();

--- a/tests/eta.test.ts
+++ b/tests/eta.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { computeETA, parseTimeToSec, type TripStop } from '../src/data/eta';
+import { computeETA, parseTimeToSec, computeAdherenceSec, type TripStop } from '../src/data/eta';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -349,5 +349,52 @@ describe('computeETA', () => {
       expect(result!.eta).toBeGreaterThan(70);
       expect(result!.eta).toBeLessThan(110);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAdherenceSec
+// ---------------------------------------------------------------------------
+
+describe('computeAdherenceSec', () => {
+  // 2026-05-20 04:00:00 UTC = midnight ET (EDT, UTC-4)
+  const midnight_et_unix = 1747713600;
+
+  test('on-time bus returns 0', () => {
+    // 18:30 ET = midnight_et + 18h30m
+    const rtArrival = midnight_et_unix + 18 * 3600 + 30 * 60;
+    const result = computeAdherenceSec(rtArrival, "18:30:00");
+    expect(result).toBe(0);
+  });
+
+  test('bus 5 min late returns positive', () => {
+    const rtArrival = midnight_et_unix + 18 * 3600 + 35 * 60; // arrived at 18:35 ET
+    const result = computeAdherenceSec(rtArrival, "18:30:00");
+    expect(result).toBe(300); // 5 min late
+  });
+
+  test('bus 3 min early returns negative', () => {
+    const rtArrival = midnight_et_unix + 18 * 3600 + 27 * 60; // arrived at 18:27 ET
+    const result = computeAdherenceSec(rtArrival, "18:30:00");
+    expect(result).toBe(-180); // 3 min early
+  });
+
+  test('delta beyond 30 min returns null', () => {
+    const rtArrival = midnight_et_unix + 20 * 3600; // 20:00 ET, scheduled 18:30 = 90 min late
+    const result = computeAdherenceSec(rtArrival, "18:30:00");
+    expect(result).toBeNull();
+  });
+
+  test('overnight GTFS time (25:30:00) adjusts service day', () => {
+    // 25:30:00 means 1:30 AM the next calendar day, but same service day as yesterday
+    // Real arrival at 1:30 AM next day = midnight_et + 25.5 hours
+    const rtArrival = midnight_et_unix + 25 * 3600 + 30 * 60;
+    const result = computeAdherenceSec(rtArrival, "25:30:00");
+    expect(result).toBe(0);
+  });
+
+  test('malformed time string returns null', () => {
+    expect(computeAdherenceSec(1747713600, "abc")).toBeNull();
+    expect(computeAdherenceSec(1747713600, "")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

`computeAdherenceSec` always returns `null` on UTC servers (Fly.io). PR #19 partially fixed the timezone issue but the midnight computation still uses the server's local timezone:

```ts
// BEFORE (broken): midnight in server TZ (UTC), not ET
const todayMidnightSec = new Date(etNow.getFullYear(), etNow.getMonth(), etNow.getDate()).getTime() / 1000;

// AFTER (fixed): midnight ET derived from real Unix timestamp
const elapsedSinceETMidnight = etNow.getHours() * 3600 + etNow.getMinutes() * 60 + etNow.getSeconds();
const todayMidnightSec = rtArrivalSec - elapsedSinceETMidnight;
```

Also moved `computeAdherenceSec` from `realtime.ts` to `eta.ts` (pure computation module, no side effects) for testability.

Closes #29

## Test plan

- [x] `bun test` — 45 tests pass (6 new adherence tests)
- [x] New tests cover: on-time (delta=0), 5min late (+300), 3min early (-180), >30min cap (null), overnight GTFS time (25:30:00), malformed input (null)
- [ ] Deploy and verify adherence values appear on predictions (no longer null)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWVH9FWmZxUnohcmrd6NKc)_