### PR TITLE
fix: prevent NaN corruption in direction selection

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1069,7 +1069,7 @@ class PullcordApp {
       row.addEventListener('click', () => {
         const vid = row.dataset.vehicle || null;
         const tid = row.dataset.trip || null;
-        const dir = row.dataset.dir != null ? parseInt(row.dataset.dir, 10) : null;
+        const dir = row.dataset.dir ? parseInt(row.dataset.dir, 10) : null;
 
         // Track this specific trip (or vehicle, or index for vehicleless predictions)
         this.trackedTripId = tid;


### PR DESCRIPTION
## Summary

One-line fix in `public/app.js`. When a user taps a prediction without a `directionId`, the `data-dir` attribute is an empty string. The check `row.dataset.dir != null` passes for empty strings, causing `parseInt("", 10)` to return `NaN`, which permanently corrupts `this.selectedDirection` for the session.

Changed from loose null check to truthy check so empty strings correctly fall through to `null`:

```js
// Before:
const dir = row.dataset.dir != null ? parseInt(row.dataset.dir, 10) : null;
// After:
const dir = row.dataset.dir ? parseInt(row.dataset.dir, 10) : null;
```

Closes #33

## Test plan

- [x] `bun test` — all tests pass
- [ ] Tap a scheduled (vehicleless) prediction, verify direction filter still works
- [ ] Tap predictions in both directions, verify hero display tracks correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMNWJPUYppgBMZnpTG9QCF)_