### PR TITLE
fix: detect stale bus in ride view and clean up poll interval

### DIFF
--- a/public/ride.js
+++ b/public/ride.js
@@ -25,8 +25,11 @@
   let followBus = true; // map follows bus by default
   let routeShortName = '';
   let routeColor = '#E85D3A';
+  let missCount = 0;
+  let pollId = null;
   const CORD_ZONE_STOPS = 2;
   const BUS_POLL_MS = 10000;
+  const MAX_MISSES = 3;
 
   // ─── Init ───
 
@@ -84,7 +87,7 @@
 
     // Poll bus position immediately + interval
     pollBus();
-    setInterval(pollBus, BUS_POLL_MS);
+    pollId = setInterval(pollBus, BUS_POLL_MS);
 
     // If user pans/zooms, stop following bus
     map.on('dragstart', () => { followBus = false; });
@@ -212,7 +215,17 @@
       const data = await res.json();
       const vehicles = data.vehicles || [];
       const bus = vehicles.find(v => v.tripId === tripId);
-      if (!bus) return;
+      if (!bus) {
+        missCount++;
+        if (missCount >= MAX_MISSES) {
+          setStatus('Bus position unavailable — trip may have ended');
+          if (busMarker) busMarker.setOpacity(0.4);
+          clearInterval(pollId);
+        }
+        return;
+      }
+
+      missCount = 0;
 
       busLatLon = [bus.lat, bus.lon];
       busBearing = bus.bearing || 0;


### PR DESCRIPTION
## Summary

Two related fixes in `public/ride.js`:

- **Stale bus detection** — when `pollBus()` can't find the tracked vehicle for 3 consecutive polls (~30s), it now updates the status to "Bus position unavailable — trip may have ended" and dims the bus marker (opacity 0.4). Previously the UI froze silently at the last known state.

- **Poll interval cleanup** — the `setInterval` return value is now stored so it can be cleared when the bus disappears. Previously the interval ID was discarded, causing the poll to run every 10 seconds forever, even after the trip ended.

Closes #34

## Test plan

- [x] `bun test` — all tests pass
- [ ] Open ride view, let a bus complete its trip — verify stale status message appears
- [ ] Verify polling stops after the stale message (check network tab)
- [ ] Verify normal ride tracking still works when bus is present

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMNWJPUYppgBMZnpTG9QCF)_