### PR TITLE
Fix: Cache /health endpoint response with 30s TTL

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -132,14 +132,25 @@ import { getTripLookup } from "./data/db.js";
 import { isRefreshing } from "./data/gtfs-import.js";
 import { getScheduleStatus } from "./data/schedules.js";
 
+// 30-second TTL cache for /health to avoid opening fresh DB connections on every poll
+let healthCache: { data: Record<string, unknown>; status: number; expiresAt: number } | null = null;
+const HEALTH_CACHE_TTL_MS = 30_000;
+
 app.get("/health", async (c) => {
+  const now = Date.now();
+  if (healthCache && now < healthCache.expiresAt) {
+    return c.json(healthCache.data, healthCache.status as 200);
+  }
+
   const dbCheck = verifyDatabase();
   if (!dbCheck.ok) {
-    return c.json({
+    const data = {
       status: "unhealthy",
       timestamp: new Date().toISOString(),
       db: dbCheck,
-    }, 503);
+    };
+    // Don't cache unhealthy responses — re-check on next request
+    return c.json(data, 503);
   }
 
   // GTFS staleness check — only when vehicle cache is already warm (no network call)
@@ -154,13 +165,17 @@ app.get("/health", async (c) => {
     }
   }
 
-  return c.json({
+  const data = {
     status: "healthy",
     timestamp: new Date().toISOString(),
     db: { version: dbCheck.version, tables: dbCheck.tables },
     schedule: getScheduleStatus(),
     ...(gtfs && { gtfs }),
-  });
+  };
+
+  healthCache = { data, status: 200, expiresAt: now + HEALTH_CACHE_TTL_MS };
+
+  return c.json(data);
 });
 
 // Diagnostic endpoint — actively probes MARTA realtime API and reports detailed status


### PR DESCRIPTION
## Summary

- Adds a 30-second TTL cache around the `/health` endpoint response in `src/app.ts`
- Prevents opening 2 fresh SQLite connections and running ~8 queries (including `COUNT(*)` on 1M+ row tables) on every Fly.io health check poll
- Unhealthy (503) responses are deliberately **not** cached, so recovery is detected immediately on the next request

Closes #36

## Test plan

- [x] `bun test` — all 39 tests pass
- [ ] Deploy and verify `/health` returns correct data
- [ ] Confirm repeated `/health` calls within 30s don't trigger new DB connections

---
_Generated by [Claude Code](https://claude.ai/code/session_012CAxmF97M9Rx4TyWtvFwPx)_