### PR TITLE
fix: ride.js scroll thrashing, stale trip state, poll races

### DIFF
--- a/public/ride.js
+++ b/public/ride.js
@@ -27,6 +27,9 @@
   let routeColor = '#E85D3A';
   let missCount = 0;
   let busPollTimer = null;
+  let tripEnded = false;
+  let polling = false;
+  let prevBusStopIndex = -1;
   const CORD_ZONE_STOPS = 2;
   const BUS_POLL_MS = 10000;
   const MAX_MISSES = 3;
@@ -107,9 +110,11 @@
         }
       } else {
         // Tab is visible again — immediate fetch, restart intervals + GPS
-        pollBus();
-        if (busPollTimer) clearInterval(busPollTimer);
-        busPollTimer = setInterval(pollBus, BUS_POLL_MS);
+        if (!tripEnded) {
+          pollBus();
+          if (busPollTimer) clearInterval(busPollTimer);
+          busPollTimer = setInterval(pollBus, BUS_POLL_MS);
+        }
         startTracking();
       }
     });
@@ -229,6 +234,8 @@
 
   async function pollBus() {
     if (!routeId) return;
+    if (polling) return;
+    polling = true;
     try {
       const res = await fetch(`/api/realtime/${routeId}`);
       if (!res.ok) return;
@@ -241,6 +248,8 @@
           setStatus('Bus position unavailable — trip may have ended');
           if (busMarker) busMarker.setOpacity(0.4);
           clearInterval(busPollTimer);
+          busPollTimer = null;
+          tripEnded = true;
         }
         return;
       }
@@ -277,7 +286,9 @@
       if (followBus) {
         map.setView(busLatLon, Math.max(map.getZoom(), 16), { animate: true });
       }
-    } catch (err) { /* silent */ }
+    } catch (err) { /* silent */ } finally {
+      polling = false;
+    }
   }
 
   function makeBusIcon(bearing) {
@@ -299,6 +310,7 @@
 
   function startTracking() {
     if (!navigator.geolocation) return;
+    if (watchId != null) return;
 
     watchId = navigator.geolocation.watchPosition(
       (pos) => {
@@ -402,10 +414,13 @@
       el.classList.toggle('ride-stop-current', i === busStopIndex);
     });
 
-    // Scroll bus's current stop into view
-    const current = document.querySelector('.ride-stop-current');
-    if (current) {
-      current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Only scroll when the bus advances to a new stop
+    if (busStopIndex !== prevBusStopIndex) {
+      prevBusStopIndex = busStopIndex;
+      const current = document.querySelector('.ride-stop-current');
+      if (current) {
+        current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes four related reliability and UX bugs in the ride-tracking view (`public/ride.js`):

- **Scroll only on stop change**: `scrollIntoView` was firing every 10s poll, yanking users away from wherever they'd scrolled. Now only scrolls when the bus advances to a new stop.
- **Sticky trip-ended state**: When a trip ends (`missCount >= MAX_MISSES`), the state now persists across tab visibility changes instead of resetting and restarting zombie polling.
- **Poll re-entrancy guard**: Prevents concurrent `pollBus()` executions on slow connections that could corrupt shared state.
- **Duplicate GPS watch guard**: Prevents `startTracking()` from creating multiple geolocation watches.

Closes #44

## Test plan

- [x] `bun test` passes
- [ ] Open ride view, verify stop list is scrollable without being yanked back every 10s
- [ ] Wait for trip to end (or simulate), switch tabs and return — confirm "trip ended" stays
- [ ] On slow connection, verify no concurrent poll race conditions

---
_Generated by [Claude Code](https://claude.ai/code/session_0188PccZUjoE6pFcN1e3a9a2)_