### PR TITLE
fix: security headers, push-sw middleware, rail param validation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -83,6 +83,8 @@ app.use("*", async (c, next) => {
   c.header("X-Frame-Options", "DENY");
   c.header("X-XSS-Protection", "1; mode=block");
   c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+  c.header("Strict-Transport-Security", "max-age=63072000; includeSubDomains");
+  c.header("Permissions-Policy", "geolocation=(self), push=(self), camera=(), microphone=()");
   c.header(
     "Content-Security-Policy",
     "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' https://unpkg.com 'unsafe-inline'; connect-src 'self' https://developerservices.itsmarta.com:*; img-src 'self' https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com data: blob:; font-src 'self'; worker-src 'self'; manifest-src 'self'"
@@ -116,12 +118,10 @@ app.route("/", statsRoutes);
 // Serve push SW from root scope (SW scope = path of the file)
 app.get("/push-sw.js", async (c) => {
   const file = Bun.file("./public/push-sw.js");
-  return new Response(await file.arrayBuffer(), {
-    headers: {
-      "Content-Type": "application/javascript",
-      "Service-Worker-Allowed": "/",
-    },
-  });
+  c.header("Content-Type", "application/javascript");
+  c.header("Service-Worker-Allowed", "/");
+  c.header("Cache-Control", "no-cache");
+  return c.body(await file.arrayBuffer());
 });
 
 // Health check endpoint — verifies DB is queryable

--- a/src/routes/bus.tsx
+++ b/src/routes/bus.tsx
@@ -175,7 +175,7 @@ app.get("/bus", async (c) => {
 // Redirect old /stop URLs to /bus
 app.get("/stop", (c) => {
   const stopId = c.req.query("id");
-  return stopId ? c.redirect(`/bus?stop=${stopId}`) : c.redirect("/");
+  return stopId ? c.redirect(`/bus?stop=${encodeURIComponent(stopId)}`) : c.redirect("/");
 });
 
 export default app;

--- a/src/routes/rail.tsx
+++ b/src/routes/rail.tsx
@@ -11,6 +11,9 @@ import {
 
 type Env = { Variables: { isRailHost: boolean } };
 
+const TRAIN_ID_RE = /^[a-zA-Z0-9_-]{1,20}$/;
+const SLUG_RE = /^[a-z0-9-]{1,60}$/;
+
 const app = new Hono<Env>();
 
 // GET /rail — landing page (all stations)
@@ -29,6 +32,7 @@ app.get("/rail", async (c) => {
 // GET /rail/train/:trainId — train timeline
 app.get("/rail/train/:trainId", async (c) => {
   const trainId = c.req.param("trainId");
+  if (!TRAIN_ID_RE.test(trainId)) return c.notFound();
   const arrivals = await fetchArrivals();
   const partial = c.req.query("partial");
   const isRailHost = c.get("isRailHost") || false;
@@ -45,6 +49,7 @@ app.get("/rail/train/:trainId", async (c) => {
 // GET /rail/:slug — station detail
 app.get("/rail/:slug", async (c) => {
   const slug = c.req.param("slug");
+  if (!SLUG_RE.test(slug)) return c.notFound();
   const arrivals = await fetchArrivals();
   const isRailHost = c.get("isRailHost") || false;
 


### PR DESCRIPTION
## Summary

Five defense-in-depth security improvements:

- **HSTS header**: Added `Strict-Transport-Security: max-age=63072000; includeSubDomains` to close the MITM window on first HTTP request
- **Permissions-Policy**: Restricts geolocation/push to same-origin, blocks camera/microphone
- **push-sw.js middleware**: Refactored from raw `new Response()` to `c.body()` so the service worker JS flows through the security headers middleware
- **Rail param validation**: Added regex validation for `:trainId` and `:slug` route params (matching bus route discipline)
- **Stop redirect encoding**: Applied `encodeURIComponent()` to the legacy `/stop` redirect

Closes #45

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` passes (45/45)
- [ ] Verify HSTS and Permissions-Policy headers present via curl
- [ ] Verify `/push-sw.js` now includes security headers
- [ ] Verify `/rail/train/<script>` returns 404
- [ ] Verify `/stop?id=foo%22bar` redirects with proper encoding

---
_Generated by [Claude Code](https://claude.ai/code/session_0188PccZUjoE6pFcN1e3a9a2)_