### PR TITLE
fix: push service worker silent notification loss on bad JSON

### DIFF
--- a/public/push-sw.js
+++ b/public/push-sw.js
@@ -2,7 +2,12 @@
 // This SW exists solely to receive push events and show notifications
 
 self.addEventListener('push', (event) => {
-  const data = event.data ? event.data.json() : {};
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (e) {
+    data = { title: 'Bus Alert', body: 'Your bus may be arriving soon' };
+  }
   const title = data.title || 'Pullcord';
   const options = {
     body: data.body || 'Your bus is arriving soon!',


### PR DESCRIPTION
## Summary

Wraps `event.data.json()` in the push service worker with try/catch. Previously, a malformed push payload would throw an uncaught `SyntaxError`, silently swallowing the notification — the user would miss their bus alert with zero indication.

Now falls back to a generic "Bus Alert — Your bus may be arriving soon" notification so the user at least sees *something*.

This is the critical path for the app's signature "pull the cord" feature.

Closes #46

## Test plan

- [x] `bun test` passes
- [ ] Test push notification with valid JSON payload — works as before
- [ ] Test push notification with malformed payload — shows fallback notification instead of silent failure

---
_Generated by [Claude Code](https://claude.ai/code/session_0188PccZUjoE6pFcN1e3a9a2)_