### PR TITLE
fix: accessibility gaps and dot-terminal CSS bug

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -801,7 +801,7 @@
      STALENESS DOTS (shared)
      ────────────────────────────── */
 
-  .dot-live, .dot-delayed, .dot-stale, .dot-lost, .dot-rescued {
+  .dot-live, .dot-delayed, .dot-stale, .dot-lost, .dot-rescued, .dot-terminal {
     display: inline-block;
     width: 7px;
     height: 7px;

--- a/src/views/pages/BusTracker.tsx
+++ b/src/views/pages/BusTracker.tsx
@@ -111,10 +111,10 @@ export const BusTrackerPage = (props: BusTrackerPageProps) => {
           <div id="cord-idle" class="d-cord-idle">
             <div class="d-cord-label" id="cord-label">🔔 Alert me</div>
             <div id="cord-options" class="d-cord-options">
-              <button class="d-cord-option" data-minutes="2" type="button">2m</button>
-              <button class="d-cord-option" data-minutes="5" type="button">5m</button>
-              <button class="d-cord-option" data-minutes="10" type="button">10m</button>
-              <button class="d-cord-option" data-minutes="15" type="button">15m</button>
+              <button class="d-cord-option" data-minutes="2" type="button" aria-label="Alert me 2 minutes before arrival">2m</button>
+              <button class="d-cord-option" data-minutes="5" type="button" aria-label="Alert me 5 minutes before arrival">5m</button>
+              <button class="d-cord-option" data-minutes="10" type="button" aria-label="Alert me 10 minutes before arrival">10m</button>
+              <button class="d-cord-option" data-minutes="15" type="button" aria-label="Alert me 15 minutes before arrival">15m</button>
             </div>
           </div>
           <div id="cord-active-display" class="d-cord-active hidden">

--- a/src/views/pages/Home.tsx
+++ b/src/views/pages/Home.tsx
@@ -26,20 +26,21 @@ export const HomePage = () => (
             class="home-search"
             placeholder="search stop name or route number"
             autocomplete="off"
+            aria-label="Search for a bus stop or route"
           />
         </div>
 
         {/* Location + Map row — collapses when searching */}
         <div class="home-locate-row">
           <button id="location-btn" class="home-locate-btn">
-            <svg class="home-locate-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="home-locate-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
             </svg>
             Find My Stop
           </button>
           <a href="/explore" class="home-map-btn">
-            <svg class="home-locate-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="home-locate-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.447 2.724A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
             </svg>
             Map


### PR DESCRIPTION
## Summary

Four accessibility and visual fixes:

- **Search input**: Added `aria-label="Search for a bus stop or route"` — the primary interaction point was unlabeled for screen readers (WCAG 2.1 Level A)
- **Decorative SVGs**: Added `aria-hidden="true"` to icon SVGs in buttons/links so screen readers don't announce path data
- **Cord buttons**: Added descriptive `aria-label`s ("Alert me 2 minutes before arrival", etc.) to the pull-the-cord threshold buttons
- **dot-terminal CSS**: Added `.dot-terminal` to the shared base dot styles selector so terminal status dots get `display: inline-block`, `width`, `height`, and `border-radius` instead of rendering as invisible inline elements

Closes #47

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` passes (45/45)
- [ ] Screen reader test: search input is announced with label
- [ ] Screen reader test: cord buttons describe their purpose
- [ ] Visual check: terminal dots now render as visible circles

---
_Generated by [Claude Code](https://claude.ai/code/session_0188PccZUjoE6pFcN1e3a9a2)_