### PR TITLE
feat: "Creamy Forest" palette overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ data/cords.db*
 data/marta.db-*
 public/rail.js
 app.js
+.claude/

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -44,18 +44,18 @@ Plus `preconnect` setup cost (~100ms DNS+TLS to two origins).
 All colors defined as CSS vars on `:root`, overridden in `@media (prefers-color-scheme: dark)`.
 
 ### Brand
-- **Primary:** `#E85D3A` (coral/orange) — used for CTAs, active states, the cord, logo
-- **Brand hover:** `#D24A31`
-- **Brand active:** `#BC3F28`
+- **Primary:** `#6B8E23` (forest green) — used for CTAs, active states, the cord, logo
+- **Brand hover:** `#5A7A1E`
+- **Brand active:** `#4A6A18`
 
 ### Semantic Colors (Light / Dark)
 | Token | Light | Dark | Usage |
 |-------|-------|------|-------|
-| `--bg-primary` | `#FDF8F2` (warm cream) | `#090E1A` (near-black blue) | Page background |
-| `--bg-surface` | `#FFF` | `#111827` | Cards, elevated surfaces |
-| `--text-primary` | `#3B2820` (warm brown) | `#F1F5F9` | Headings, stop names |
-| `--text-body` | `#5C4030` | `#CBD5E1` | Body text |
-| `--text-muted` | `#A89282` | `#8896A8` | Secondary info, timestamps |
+| `--bg-primary` | `#FDFBD4` (cream) | `#0A1A0E` (dark forest) | Page background |
+| `--bg-surface` | `#FFFFF0` (ivory) | `#132A18` | Cards, elevated surfaces |
+| `--text-primary` | `#2D3A20` (dark forest) | `#E8F0E4` | Headings, stop names |
+| `--text-body` | `#4A5A3A` | `#B8CCB0` | Body text |
+| `--text-muted` | `#7A8B6A` | `#7A9A70` | Secondary info, timestamps |
 | `--live-green` | `#0D9488` (teal) | `#22C55E` (green) | Live status dots |
 | `--live-delayed` | `#F0A030` (amber) | `#EAB308` (yellow) | Delayed/late |
 

--- a/public/app.js
+++ b/public/app.js
@@ -347,7 +347,7 @@ class PullcordApp {
     this.data = window.__INITIAL_DATA__;
     this.config = window.__CONFIG__;
     this.multiRoute = !!this.config.multiRoute;
-    this.routeColor = this.data.route?.color ? `#${this.data.route.color}` : '#E85D3A';
+    this.routeColor = this.data.route?.color ? `#${this.data.route.color}` : '#6B8E23';
     const params = new URLSearchParams(window.location.search);
     this.mockMode = params.has('mock');
 
@@ -425,7 +425,7 @@ class PullcordApp {
         direction: s.direction_id, sequence: s.stop_sequence ?? 0
       }));
       this.data.shapes = rd.shapes || [];
-      this.routeColor = rd.route?.route_color ? `#${rd.route.route_color}` : '#E85D3A';
+      this.routeColor = rd.route?.route_color ? `#${rd.route.route_color}` : '#6B8E23';
       this.loadedRouteId = routeId;
 
       // Re-prepare stop directions for progress strip
@@ -856,7 +856,7 @@ class PullcordApp {
     const hsEl = document.getElementById('hero-headsign');
     const fullHeadsign = this.heroPrediction.headsign || 'Unknown';
     hsEl.innerHTML = this.multiRoute && this.heroPrediction.routeBadge
-      ? `<span class="d-hero-route" style="color:#${this.heroPrediction.routeColor || 'E85D3A'}">${this.esc(this.heroPrediction.routeBadge)}</span> <span class="d-hero-headsign-text">${this.esc(fullHeadsign)}</span>`
+      ? `<span class="d-hero-route" style="color:#${this.heroPrediction.routeColor || '6B8E23'}">${this.esc(this.heroPrediction.routeBadge)}</span> <span class="d-hero-headsign-text">${this.esc(fullHeadsign)}</span>`
       : `<span class="d-hero-headsign-text">${this.esc(fullHeadsign)}</span>`;
 
     // Measure actual overflow, then middle-truncate if needed
@@ -980,11 +980,11 @@ class PullcordApp {
 
     // Adaptive colors
     const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const stripLine = dark ? '#1e293b' : '#EDE5D8';
-    const stopDot = dark ? '#475569' : '#C4B4A4';
-    const myStopStroke = dark ? '#090e1a' : '#FFFFFF';
-    const labelFill = dark ? '#94a3b8' : '#7C6354';
-    const busFill = dark ? '#f8fafc' : '#3B2820';
+    const stripLine = dark ? '#1e3a20' : '#D8E5C8';
+    const stopDot = dark ? '#475569' : '#B4C4A4';
+    const myStopStroke = dark ? '#0a1a0e' : '#FFFFFF';
+    const labelFill = dark ? '#94a3b8' : '#5A6B4A';
+    const busFill = dark ? '#f8fafc' : '#2D3A20';
 
     // Positions: bus at left, me at right, between-stops evenly spaced
     const totalSlots = betweenCount + 1; // segments between bus and me
@@ -1044,7 +1044,7 @@ class PullcordApp {
     const pad = 20;
     const lineY = 16;
     const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const stripLine = dark ? '#1e293b' : '#EDE5D8';
+    const stripLine = dark ? '#1e3a20' : '#D8E5C8';
 
     strip.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">` +
       `<line x1="${pad}" y1="${lineY}" x2="${w-pad}" y2="${lineY}" stroke="${stripLine}" stroke-width="2" stroke-linecap="round"/>` +
@@ -1162,7 +1162,7 @@ class PullcordApp {
     // Route badge for multi-route mode
     // Route number for multi-route mode — bold colored text, no pill
     const routeNum = this.multiRoute && pred.routeBadge
-      ? `<span class="d-upcoming-route" style="color:#${pred.routeColor || 'E85D3A'}">${this.esc(pred.routeBadge)}</span>`
+      ? `<span class="d-upcoming-route" style="color:#${pred.routeColor || '6B8E23'}">${this.esc(pred.routeBadge)}</span>`
       : '';
 
     return `
@@ -1614,7 +1614,7 @@ class PullcordApp {
       if (coords.length === 0) return;
       // Outline
       const outline = L.polyline(coords, {
-        color: '#1e293b', weight: 8, opacity: 0.8,
+        color: '#1e3a20', weight: 8, opacity: 0.8,
         lineCap: 'round', lineJoin: 'round'
       }).addTo(this.map);
       this.routePolylines.push(outline);

--- a/public/app.js
+++ b/public/app.js
@@ -981,7 +981,7 @@ class PullcordApp {
     // Adaptive colors
     const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const stripLine = dark ? '#1e3a20' : '#D8E5C8';
-    const stopDot = dark ? '#475569' : '#B4C4A4';
+    const stopDot = dark ? '#5a7a50' : '#B4C4A4';
     const myStopStroke = dark ? '#0a1a0e' : '#FFFFFF';
     const labelFill = dark ? '#94a3b8' : '#5A6B4A';
     const busFill = dark ? '#f8fafc' : '#2D3A20';
@@ -1157,7 +1157,7 @@ class PullcordApp {
 
     // Row color — use route color in multi-route, otherwise by tier
     const predColor = pred.routeColor ? `#${pred.routeColor}` : this.routeColor;
-    const rowColor = tier === 'next' ? '#60a5fa' : tier === 'scheduled' ? '#334155' : predColor;
+    const rowColor = tier === 'next' ? '#60a5fa' : tier === 'scheduled' ? '#5a7a50' : predColor;
 
     // Route badge for multi-route mode
     // Route number for multi-route mode — bold colored text, no pill

--- a/public/explore.js
+++ b/public/explore.js
@@ -154,7 +154,7 @@
     toRender.forEach(stop => {
       const marker = L.circleMarker([stop.stop_lat, stop.stop_lon], {
         radius: 6,
-        fillColor: '#E85D3A',
+        fillColor: '#6B8E23',
         fillOpacity: 0.85,
         color: '#fff',
         weight: 1.5,
@@ -196,7 +196,7 @@
 
       const marker = L.circleMarker([lat, lon], {
         radius,
-        fillColor: '#E85D3A',
+        fillColor: '#6B8E23',
         fillOpacity: 0.7,
         color: '#fff',
         weight: 2,

--- a/public/icons/favicon.svg
+++ b/public/icons/favicon.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44">
   <!-- Cord -->
-  <line x1="22" y1="2" x2="22" y2="16" stroke="#E85D3A" stroke-width="3" stroke-linecap="round"/>
+  <line x1="22" y1="2" x2="22" y2="16" stroke="#6B8E23" stroke-width="3" stroke-linecap="round"/>
   <!-- Handle body -->
-  <rect x="12" y="16" width="20" height="18" rx="6" fill="#E85D3A"/>
+  <rect x="12" y="16" width="20" height="18" rx="6" fill="#6B8E23"/>
   <!-- Handle grip detail -->
   <rect x="16" y="22" width="12" height="6" rx="3" fill="#fff" opacity="0.3"/>
   <!-- Tiny highlight -->
-  <circle cx="22" cy="40" r="2" fill="#F0A030" opacity="0.6"/>
+  <circle cx="22" cy="40" r="2" fill="#A3C6A8" opacity="0.6"/>
 </svg>

--- a/public/icons/pullcord.svg
+++ b/public/icons/pullcord.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44" fill="none">
   <!-- Cord -->
-  <line x1="22" y1="2" x2="22" y2="16" stroke="#E85D3A" stroke-width="3" stroke-linecap="round"/>
+  <line x1="22" y1="2" x2="22" y2="16" stroke="#6B8E23" stroke-width="3" stroke-linecap="round"/>
   <!-- Handle body -->
-  <rect x="12" y="16" width="20" height="18" rx="6" fill="#E85D3A"/>
+  <rect x="12" y="16" width="20" height="18" rx="6" fill="#6B8E23"/>
   <!-- Handle grip detail -->
   <rect x="16" y="22" width="12" height="6" rx="3" fill="#fff" opacity="0.3"/>
   <!-- Tiny highlight -->
-  <circle cx="22" cy="40" r="2" fill="#F0A030" opacity="0.6"/>
+  <circle cx="22" cy="40" r="2" fill="#A3C6A8" opacity="0.6"/>
 </svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,8 +4,8 @@
   "description": "Pull the cord. Catch your ride. Real-time MARTA bus tracking.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#FDF8F2",
-  "theme_color": "#E85D3A",
+  "background_color": "#FDFBD4",
+  "theme_color": "#6B8E23",
   "orientation": "portrait",
   "icons": [
     {

--- a/public/ride.js
+++ b/public/ride.js
@@ -146,7 +146,7 @@
     const coords = stops.map(s => [s.lat, s.lon]);
     // Outline
     L.polyline(coords, {
-      color: prefersDark ? '#1e293b' : '#94a3b8',
+      color: prefersDark ? '#1e3a20' : '#94a3b8',
       weight: 7, opacity: 0.5, lineCap: 'round', lineJoin: 'round',
     }).addTo(map);
     L.polyline(coords, {

--- a/public/ride.js
+++ b/public/ride.js
@@ -24,7 +24,7 @@
   let cordZoneActive = false;
   let followBus = true; // map follows bus by default
   let routeShortName = '';
-  let routeColor = '#E85D3A';
+  let routeColor = '#6B8E23';
   let missCount = 0;
   let busPollTimer = null;
   let tripEnded = false;

--- a/src/rail/views.ts
+++ b/src/rail/views.ts
@@ -10,7 +10,7 @@
 
 const CSS = `<style>
 *{margin:0;padding:0;box-sizing:border-box}
-:root{--bg:#0c0c0c;--card:#151515;--text:#d4d0c8;--dim:#8a8478;--border:#222;--coral:#e8725a}
+:root{--bg:#0a1a0e;--card:#132a18;--text:#e8f0e4;--dim:#7a9a70;--border:#1e3a20;--coral:#6B8E23}
 body{background:var(--bg);color:var(--text);font-family:-apple-system,system-ui,sans-serif;-webkit-font-smoothing:antialiased}
 a{color:inherit;text-decoration:none}
 .wrap{max-width:480px;margin:0 auto;min-height:100dvh;display:flex;flex-direction:column}
@@ -29,7 +29,7 @@ const ABOUT_CSS = `.about-section{padding:1rem;border-bottom:1px solid var(--bor
 .about-section h2{font-size:0.95rem;font-weight:600;color:var(--coral);margin-bottom:0.5rem;text-transform:uppercase;letter-spacing:0.05em}
 .about-section p{font-size:0.92rem;line-height:1.55;color:var(--text);margin-bottom:0.6rem}
 .about-section p:last-child{margin-bottom:0}
-.about-section a{color:var(--coral);border-bottom:1px solid rgba(232,114,90,0.3)}
+.about-section a{color:var(--coral);border-bottom:1px solid rgba(107,142,35,0.3)}
 .about-muted{color:var(--dim);font-size:0.85rem !important}
 .about-tag{display:inline-block;padding:0.2rem 0.5rem;margin:0.15rem 0.2rem 0.15rem 0;font-size:0.82rem;background:var(--card);border-radius:3px;color:var(--text)}
 .about-stat-row{display:flex;gap:0.5rem;flex-wrap:wrap;margin-top:0.5rem}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1228,7 +1228,7 @@
     gap: 0.4rem;
     flex: 1;
     padding: 0.7rem 1rem;
-    background: var(--brand);
+    background: var(--brand-hover);
     color: #fff;
     font-size: 0.95rem;
     font-weight: 600;
@@ -1239,10 +1239,10 @@
     box-shadow: 0 2px 8px rgba(107, 142, 35, 0.2);
   }
 
-  .home-locate-btn:hover { background: var(--brand-hover); }
+  .home-locate-btn:hover { background: var(--brand-active); }
   .home-locate-btn:active {
     transform: scale(0.98);
-    background: var(--brand-active);
+    background: #3D5A13;
     box-shadow: 0 2px 8px rgba(107, 142, 35, 0.2);
   }
   .home-locate-btn:disabled {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9,9 +9,9 @@
     Arial, sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas,
     monospace;
-  --color-brand: #E85D3A;
-  --color-brand-hover: #D24A31;
-  --color-brand-active: #BC3F28;
+  --color-brand: #6B8E23;
+  --color-brand-hover: #5A7A1E;
+  --color-brand-active: #4A6A18;
 }
 
 /* ===== BASE ===== */
@@ -22,14 +22,14 @@
     height: 100%;
   }
 
-  /* ── Light Mode (default) — C's warm palette ── */
+  /* ── Light Mode (default) — Creamy Forest palette ── */
   :root {
     /* Brand — consistent across modes */
-    --brand: #E85D3A;
-    --coral: #E85D3A;
+    --brand: #6B8E23;
+    --coral: #6B8E23;
     --surface-raised: var(--bg-surface);
-    --brand-hover: #D24A31;
-    --brand-active: #BC3F28;
+    --brand-hover: #5A7A1E;
+    --brand-active: #4A6A18;
 
     /* Cord — semantic, same in both modes */
     --cord-red: #dc2626;
@@ -37,25 +37,25 @@
     --cord-fired: #22c55e;
 
     /* Background layers */
-    --bg-primary: #FDF8F2;
-    --bg-secondary: #FAF5EE;
-    --bg-surface: #FFFFFF;
-    --bg-elevated: #FFFFFF;
+    --bg-primary: #FDFBD4;
+    --bg-secondary: #F8F5C8;
+    --bg-surface: #FFFFF0;
+    --bg-elevated: #FFFFF0;
 
     /* Text hierarchy */
-    --text-primary: #3B2820;
-    --text-heading: #3B2820;
-    --text-body: #5C4030;
-    --text-secondary: #6B5445;
-    --text-muted: #8B7462;
-    --text-dim: #9E8E7E;
-    --text-faint: #D4C4B4;
+    --text-primary: #2D3A20;
+    --text-heading: #2D3A20;
+    --text-body: #4A5A3A;
+    --text-secondary: #5A6B4A;
+    --text-muted: #7A8B6A;
+    --text-dim: #8E9E80;
+    --text-faint: #C4D4B4;
 
     /* UI chrome */
-    --border: #EDE5D8;
-    --border-subtle: rgba(61, 44, 32, 0.05);
-    --hover-bg: rgba(232, 93, 58, 0.06);
-    --active-bg: rgba(232, 93, 58, 0.1);
+    --border: #D8E5C8;
+    --border-subtle: rgba(45, 58, 32, 0.05);
+    --hover-bg: rgba(107, 142, 35, 0.06);
+    --active-bg: rgba(107, 142, 35, 0.1);
 
     /* Status */
     --live-green: #0D9488;
@@ -64,7 +64,7 @@
     --dot-lost: #ef4444;
 
     /* Hero */
-    --hero-number: #3B2820;
+    --hero-number: #2D3A20;
     --hero-arriving: #0D9488;
     --hero-soon: #D97706;
 
@@ -74,45 +74,45 @@
     --tier-next-bg: rgba(74, 127, 181, 0.04);
 
     /* Tier: scheduled */
-    --tier-sched: #A89282;
-    --tier-sched-border: #D4C4B4;
-    --tier-sched-bg: rgba(168, 146, 130, 0.04);
+    --tier-sched: #8A9A7A;
+    --tier-sched-border: #C4D4B4;
+    --tier-sched-bg: rgba(138, 154, 122, 0.04);
 
     /* Card interactions */
-    --card-hover: #FFF8F5;
+    --card-hover: #F5FAE8;
 
     /* Search */
-    --search-bg: #FFFFFF;
-    --search-border: #EDE5D8;
-    --search-focus-shadow: rgba(232, 93, 58, 0.12);
+    --search-bg: #FFFFF0;
+    --search-border: #D8E5C8;
+    --search-focus-shadow: rgba(107, 142, 35, 0.12);
 
     /* Map */
-    --stop-pulse-color: #E85D3A;
-    --stop-pulse-shadow: rgba(232, 93, 58, 0.5);
-    --route-stop-bg: #FFFFFF;
-    --bus-marker-default: #3B2820;
+    --stop-pulse-color: #6B8E23;
+    --stop-pulse-shadow: rgba(107, 142, 35, 0.5);
+    --route-stop-bg: #FFFFF0;
+    --bus-marker-default: #2D3A20;
 
     /* Home */
-    --home-bg: radial-gradient(ellipse at top, #FFF5EB 0%, #FDF8F2 50%, #F7EFE5 100%);
+    --home-bg: radial-gradient(ellipse at top, #F8FAD0 0%, #FDFBD4 50%, #F0F2C0 100%);
   }
 
-  /* ── Dark Mode — D's transit-display palette ── */
+  /* ── Dark Mode — Dark Forest palette ── */
   @media (prefers-color-scheme: dark) {
     :root {
-      --bg-primary: #090e1a;
-      --bg-secondary: #0f1629;
-      --bg-surface: #111827;
-      --bg-elevated: #0f1629;
+      --bg-primary: #0a1a0e;
+      --bg-secondary: #0f2415;
+      --bg-surface: #132a18;
+      --bg-elevated: #0f2415;
 
-      --text-primary: #f1f5f9;
-      --text-heading: #e2e8f0;
-      --text-body: #cbd5e1;
-      --text-secondary: #94a3b8;
-      --text-muted: #8896a8;
-      --text-dim: #5a6b7d;
-      --text-faint: #3d4d5f;
+      --text-primary: #e8f0e4;
+      --text-heading: #d8e8d0;
+      --text-body: #b8ccb0;
+      --text-secondary: #8aaa80;
+      --text-muted: #7a9a70;
+      --text-dim: #4a6a40;
+      --text-faint: #2d4a28;
 
-      --border: #1e293b;
+      --border: #1e3a20;
       --border-subtle: rgba(255, 255, 255, 0.05);
       --hover-bg: rgba(255, 255, 255, 0.05);
       --active-bg: rgba(255, 255, 255, 0.08);
@@ -120,7 +120,7 @@
       --live-green: #22c55e;
       --live-delayed: #eab308;
 
-      --hero-number: #f8fafc;
+      --hero-number: #f0f8ec;
       --hero-arriving: #22c55e;
       --hero-soon: #eab308;
 
@@ -128,22 +128,22 @@
       --tier-next-accent: #60a5fa;
       --tier-next-bg: rgba(96, 165, 250, 0.04);
 
-      --tier-sched: #64748b;
-      --tier-sched-border: #334155;
-      --tier-sched-bg: rgba(100, 116, 139, 0.04);
+      --tier-sched: #5a7a50;
+      --tier-sched-border: #2d4a28;
+      --tier-sched-bg: rgba(90, 122, 80, 0.04);
 
-      --card-hover: #1a2438;
+      --card-hover: #1a3420;
 
       --search-bg: rgba(255,255,255,0.05);
       --search-border: rgba(255,255,255,0.1);
-      --search-focus-shadow: rgba(232, 93, 58, 0.15);
+      --search-focus-shadow: rgba(107, 142, 35, 0.15);
 
       --stop-pulse-color: #ef4444;
       --stop-pulse-shadow: rgba(239,68,68,0.5);
-      --route-stop-bg: #0f172a;
-      --bus-marker-default: #0f172a;
+      --route-stop-bg: #0f2415;
+      --bus-marker-default: #0f2415;
 
-      --home-bg: #090e1a;
+      --home-bg: #0a1a0e;
       --surface-raised: var(--bg-surface);
     }
   }
@@ -698,7 +698,7 @@
   }
 
   .d-upcoming-row.d-upcoming-hero {
-    background: rgba(232, 93, 58, 0.1);
+    background: rgba(107, 142, 35, 0.1);
     border-left-width: 6px;
     border-left-color: var(--color-brand);
     position: relative;
@@ -783,7 +783,7 @@
   }
 
   .d-upcoming-row.tier-next.d-upcoming-hero {
-    background: rgba(232, 93, 58, 0.1);
+    background: rgba(107, 142, 35, 0.1);
     border-left-color: var(--color-brand);
   }
 
@@ -793,7 +793,7 @@
   }
 
   .d-upcoming-row.tier-scheduled.d-upcoming-hero {
-    background: rgba(232, 93, 58, 0.1);
+    background: rgba(107, 142, 35, 0.1);
     border-left-color: var(--color-brand);
   }
 
@@ -1236,14 +1236,14 @@
     border-radius: 0.6rem;
     cursor: pointer;
     transition: background 0.15s, transform 0.1s, box-shadow 0.15s;
-    box-shadow: 0 2px 8px rgba(232, 93, 58, 0.2);
+    box-shadow: 0 2px 8px rgba(107, 142, 35, 0.2);
   }
 
   .home-locate-btn:hover { background: var(--brand-hover); }
   .home-locate-btn:active {
     transform: scale(0.98);
     background: var(--brand-active);
-    box-shadow: 0 2px 8px rgba(232, 93, 58, 0.2);
+    box-shadow: 0 2px 8px rgba(107, 142, 35, 0.2);
   }
   .home-locate-btn:disabled {
     opacity: 0.85;
@@ -1273,7 +1273,7 @@
     transition: background 0.15s, transform 0.1s;
     text-decoration: none;
   }
-  .home-map-btn:hover { background: rgba(232, 93, 58, 0.08); }
+  .home-map-btn:hover { background: rgba(107, 142, 35, 0.08); }
   .home-map-btn:active { transform: scale(0.98); }
 
   .home-locate-icon { width: 1.25rem; height: 1.25rem; flex-shrink: 0; }
@@ -1370,7 +1370,7 @@
     white-space: nowrap;
   }
   .home-map-toggle:hover {
-    background: rgba(232, 93, 58, 0.08);
+    background: rgba(107, 142, 35, 0.08);
   }
 
   .home-results-list {
@@ -1662,7 +1662,7 @@
   color: var(--brand);
   text-decoration: underline;
   text-underline-offset: 2px;
-  text-decoration-color: rgba(232, 93, 58, 0.3);
+  text-decoration-color: rgba(107, 142, 35, 0.3);
   transition: text-decoration-color 0.15s;
 }
 
@@ -2121,7 +2121,7 @@
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background: var(--coral, #E85D3A);
+  background: var(--coral, #6B8E23);
   border: 3px solid #fff;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
   display: flex;
@@ -2140,7 +2140,7 @@
   height: 0;
   border-left: 6px solid transparent;
   border-right: 6px solid transparent;
-  border-bottom: 10px solid var(--coral, #E85D3A);
+  border-bottom: 10px solid var(--coral, #6B8E23);
   filter: drop-shadow(0 1px 2px rgba(0,0,0,0.3));
 }
 

--- a/src/views/Layout.tsx
+++ b/src/views/Layout.tsx
@@ -59,8 +59,8 @@ export const Layout = (props: LayoutProps) => {
 
         {/* PWA */}
         <link rel="manifest" href="/public/manifest.json" />
-        <meta name="theme-color" content="#E85D3A" media="(prefers-color-scheme: light)" />
-        <meta name="theme-color" content="#090e1a" media="(prefers-color-scheme: dark)" />
+        <meta name="theme-color" content="#6B8E23" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#0a1a0e" media="(prefers-color-scheme: dark)" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="Pullcord" />

--- a/src/views/pages/About.tsx
+++ b/src/views/pages/About.tsx
@@ -10,10 +10,10 @@ export const AboutPage = () => (
         </a>
         <div class="about-brand">
           <svg class="about-logo" width="32" height="32" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <line x1="22" y1="2" x2="22" y2="16" stroke="#E85D3A" stroke-width="3" stroke-linecap="round"/>
-            <rect x="12" y="16" width="20" height="18" rx="6" fill="#E85D3A"/>
+            <line x1="22" y1="2" x2="22" y2="16" stroke="#6B8E23" stroke-width="3" stroke-linecap="round"/>
+            <rect x="12" y="16" width="20" height="18" rx="6" fill="#6B8E23"/>
             <rect x="16" y="22" width="12" height="6" rx="3" fill="#fff" opacity="0.3"/>
-            <circle cx="22" cy="40" r="2" fill="#F0A030" opacity="0.6"/>
+            <circle cx="22" cy="40" r="2" fill="#A3C6A8" opacity="0.6"/>
           </svg>
           <span class="about-wordmark">Pullcord</span>
         </div>

--- a/src/views/pages/BusTracker.tsx
+++ b/src/views/pages/BusTracker.tsx
@@ -11,7 +11,7 @@ export interface BusTrackerPageProps {
 export const BusTrackerPage = (props: BusTrackerPageProps) => {
   const { route, stop, routeDetail, initialData } = props;
   const multiRoute = !route;
-  const routeColor = route?.route_color ? `#${route.route_color}` : '#E85D3A';
+  const routeColor = route?.route_color ? `#${route.route_color}` : '#6B8E23';
 
   return (
     <div class="d-shell" style={`--route-color: ${routeColor}`}>

--- a/src/views/pages/Home.tsx
+++ b/src/views/pages/Home.tsx
@@ -6,10 +6,10 @@ export const HomePage = () => (
         <div class="home-header-top">
           <div class="home-brand">
             <svg class="home-logo-icon" width="32" height="32" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <line x1="22" y1="2" x2="22" y2="16" stroke="#E85D3A" stroke-width="3" stroke-linecap="round"/>
-              <rect x="12" y="16" width="20" height="18" rx="6" fill="#E85D3A"/>
+              <line x1="22" y1="2" x2="22" y2="16" stroke="#6B8E23" stroke-width="3" stroke-linecap="round"/>
+              <rect x="12" y="16" width="20" height="18" rx="6" fill="#6B8E23"/>
               <rect x="16" y="22" width="12" height="6" rx="3" fill="#fff" opacity="0.3"/>
-              <circle cx="22" cy="40" r="2" fill="#F0A030" opacity="0.6"/>
+              <circle cx="22" cy="40" r="2" fill="#A3C6A8" opacity="0.6"/>
             </svg>
             <span class="home-wordmark">Pullcord</span>
           </div>

--- a/src/views/pages/Rail.tsx
+++ b/src/views/pages/Rail.tsx
@@ -101,7 +101,7 @@ const STATION_COORDS: Record<string, [number, number]> = {
 
 // Inline JS — zero external requests, handles polling + starred/nearby reordering
 function buildInlineJS(isLanding: boolean): string {
-  const base = `(function(){var P=1e4,d=document.getElementById("rail-data"),f=document.getElementById("freshness");if(!d||!f)return;var t=Date.now(),p=null,b=window.location.pathname;function u(){var a=Math.floor((Date.now()-t)/1e3);f.textContent=a<2?"live":a+"s ago";f.style.color=a>30?"#6B8E23":""}setInterval(u,1e3);u();function q(){fetch(b+"?partial=1",{signal:AbortSignal.timeout(8e3)}).then(function(r){if(r.ok)return r.text()}).then(function(h){if(h){d.innerHTML=h;t=Date.now();u();typeof reorder==="function"&&reorder();typeof postUpdate==="function"&&postUpdate()}}).catch(function(){})}p=setInterval(q,P);document.addEventListener("visibilitychange",function(){if(document.hidden){clearInterval(p);p=null}else{q();p=setInterval(q,P)}})})();`;
+  const base = `(function(){var P=1e4,d=document.getElementById("rail-data"),f=document.getElementById("freshness");if(!d||!f)return;var t=Date.now(),p=null,b=window.location.pathname;function u(){var a=Math.floor((Date.now()-t)/1e3);f.textContent=a<2?"live":a+"s ago";f.style.color=a>30?"#D97706":""}setInterval(u,1e3);u();function q(){fetch(b+"?partial=1",{signal:AbortSignal.timeout(8e3)}).then(function(r){if(r.ok)return r.text()}).then(function(h){if(h){d.innerHTML=h;t=Date.now();u();typeof reorder==="function"&&reorder();typeof postUpdate==="function"&&postUpdate()}}).catch(function(){})}p=setInterval(q,P);document.addEventListener("visibilitychange",function(){if(document.hidden){clearInterval(p);p=null}else{q();p=setInterval(q,P)}})})();`;
 
   if (!isLanding) return base;
 

--- a/src/views/pages/Rail.tsx
+++ b/src/views/pages/Rail.tsx
@@ -101,7 +101,7 @@ const STATION_COORDS: Record<string, [number, number]> = {
 
 // Inline JS — zero external requests, handles polling + starred/nearby reordering
 function buildInlineJS(isLanding: boolean): string {
-  const base = `(function(){var P=1e4,d=document.getElementById("rail-data"),f=document.getElementById("freshness");if(!d||!f)return;var t=Date.now(),p=null,b=window.location.pathname;function u(){var a=Math.floor((Date.now()-t)/1e3);f.textContent=a<2?"live":a+"s ago";f.style.color=a>30?"#E85D3A":""}setInterval(u,1e3);u();function q(){fetch(b+"?partial=1",{signal:AbortSignal.timeout(8e3)}).then(function(r){if(r.ok)return r.text()}).then(function(h){if(h){d.innerHTML=h;t=Date.now();u();typeof reorder==="function"&&reorder();typeof postUpdate==="function"&&postUpdate()}}).catch(function(){})}p=setInterval(q,P);document.addEventListener("visibilitychange",function(){if(document.hidden){clearInterval(p);p=null}else{q();p=setInterval(q,P)}})})();`;
+  const base = `(function(){var P=1e4,d=document.getElementById("rail-data"),f=document.getElementById("freshness");if(!d||!f)return;var t=Date.now(),p=null,b=window.location.pathname;function u(){var a=Math.floor((Date.now()-t)/1e3);f.textContent=a<2?"live":a+"s ago";f.style.color=a>30?"#6B8E23":""}setInterval(u,1e3);u();function q(){fetch(b+"?partial=1",{signal:AbortSignal.timeout(8e3)}).then(function(r){if(r.ok)return r.text()}).then(function(h){if(h){d.innerHTML=h;t=Date.now();u();typeof reorder==="function"&&reorder();typeof postUpdate==="function"&&postUpdate()}}).catch(function(){})}p=setInterval(q,P);document.addEventListener("visibilitychange",function(){if(document.hidden){clearInterval(p);p=null}else{q();p=setInterval(q,P)}})})();`;
 
   if (!isLanding) return base;
 
@@ -828,27 +828,27 @@ function railStyles(): string {
   return `
     /* ── CSS Variables (design system tokens) ── */
     :root {
-      --bg-primary: #0f0f0f;
-      --bg-surface: #1a1a18;
-      --text-primary: #d4d0c8;
-      --text-body: #b0a898;
-      --text-muted: #9A9088;
-      --border-color: #2a2a26;
-      --border-subtle: #333330;
-      --brand: #E85D3A;
+      --bg-primary: #0a1a0e;
+      --bg-surface: #132a18;
+      --text-primary: #e8f0e4;
+      --text-body: #b8ccb0;
+      --text-muted: #7a9a70;
+      --border-color: #1e3a20;
+      --border-subtle: #2a4a28;
+      --brand: #6B8E23;
       --font-sans: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif;
       --font-mono: ui-monospace, Cascadia Code, Source Code Pro, Menlo, Consolas, monospace;
     }
 
     @media (prefers-color-scheme: light) {
       :root {
-        --bg-primary: #f5f0eb;
-        --bg-surface: #ece5dc;
-        --text-primary: #3B2820;
-        --text-body: #5C4030;
-        --text-muted: #8B7462;
-        --border-color: #d8cfc4;
-        --border-subtle: #e0d8cf;
+        --bg-primary: #F0F2D8;
+        --bg-surface: #E0E5C8;
+        --text-primary: #2D3A20;
+        --text-body: #4A5A3A;
+        --text-muted: #7A8B6A;
+        --border-color: #C8D4B4;
+        --border-subtle: #D0DCC0;
       }
     }
 

--- a/src/views/pages/Stats.tsx
+++ b/src/views/pages/Stats.tsx
@@ -280,7 +280,7 @@ function statsJS(): string {
     var d=document.getElementById("stats-data"),f=document.getElementById("fresh");
     if(!d||!f)return;
     var t=Date.now();
-    function u(){var a=Math.floor((Date.now()-t)/1e3);f.textContent=a<5?"live":a+"s ago";f.style.color=a>60?"#6B8E23":""}
+    function u(){var a=Math.floor((Date.now()-t)/1e3);f.textContent=a<5?"live":a+"s ago";f.style.color=a>60?"#D97706":""}
     setInterval(u,1e3);
     function poll(){fetch("/stats?partial=1",{signal:AbortSignal.timeout(8e3)}).then(function(r){if(r.ok)return r.text()}).then(function(h){if(h){d.innerHTML=h;t=Date.now();u()}}).catch(function(){})}
     var p=setInterval(poll,30000);

--- a/src/views/pages/Stats.tsx
+++ b/src/views/pages/Stats.tsx
@@ -141,7 +141,7 @@ export function StatsPage() {
         <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
         <title>System Stats — Pullcord</title>
         <meta name="description" content="MARTA on-time performance and operational health." />
-        <meta name="theme-color" content="#090e1a" />
+        <meta name="theme-color" content="#0a1a0e" />
         <link rel="icon" type="image/svg+xml" href="/public/icons/favicon.svg" />
         <style>{statsCSS()}</style>
       </head>
@@ -280,7 +280,7 @@ function statsJS(): string {
     var d=document.getElementById("stats-data"),f=document.getElementById("fresh");
     if(!d||!f)return;
     var t=Date.now();
-    function u(){var a=Math.floor((Date.now()-t)/1e3);f.textContent=a<5?"live":a+"s ago";f.style.color=a>60?"#E85D3A":""}
+    function u(){var a=Math.floor((Date.now()-t)/1e3);f.textContent=a<5?"live":a+"s ago";f.style.color=a>60?"#6B8E23":""}
     setInterval(u,1e3);
     function poll(){fetch("/stats?partial=1",{signal:AbortSignal.timeout(8e3)}).then(function(r){if(r.ok)return r.text()}).then(function(h){if(h){d.innerHTML=h;t=Date.now();u()}}).catch(function(){})}
     var p=setInterval(poll,30000);
@@ -294,13 +294,13 @@ function statsCSS(): string {
     *{box-sizing:border-box;margin:0;padding:0}
     body{
       font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
-      background:#090e1a;color:#e8e8e8;-webkit-font-smoothing:antialiased;
+      background:#0a1a0e;color:#e8f0e4;-webkit-font-smoothing:antialiased;
     }
     .s-shell{max-width:960px;margin:0 auto;padding:0 1rem}
     .s-header{
       display:flex;align-items:center;gap:.75rem;padding:1rem 0;
       border-bottom:1px solid rgba(255,255,255,.06);
-      position:sticky;top:0;background:#090e1a;z-index:10;
+      position:sticky;top:0;background:#0a1a0e;z-index:10;
     }
     .s-back{color:#aaa;text-decoration:none;display:flex}.s-back:hover{color:#fff}
     .s-h1{font-size:1.25rem;font-weight:600;letter-spacing:-.02em;flex:1}


### PR DESCRIPTION
## Summary

Closes #57. Replaces the coral/warm-brown color palette with a "Creamy Forest" theme across 15+ files.

- **Brand**: `#E85D3A` (coral) → `#6B8E23` (forest green) — all CTAs, SVG logos, JS fallbacks
- **Light backgrounds**: warm cream → `#FDFBD4` cream / `#FFFFF0` ivory
- **Text hierarchy**: warm brown → forest/olive greens (`#2D3A20` → `#8E9E80`)
- **Dark mode**: cold navy → dark forest (`#0a1a0e` base)
- **Borders/surfaces**: shifted to sage greens
- **Status colors preserved**: live-green, delayed-amber, stale-orange, error-red unchanged

### Files changed
- `src/styles/app.css` — Central CSS custom properties (light + dark mode)
- `public/manifest.json`, `src/views/Layout.tsx` — PWA theme colors
- SVG logos: `Home.tsx`, `About.tsx`, `favicon.svg`, `pullcord.svg`
- Client JS fallbacks: `app.js`, `explore.js`, `ride.js`
- Standalone pages: `Rail.tsx`, `Stats.tsx`, `rail/views.ts`
- `docs/DESIGN_SYSTEM.md` — Updated color tables

### Verification
- Zero `#E85D3A` / `#D24A31` / `#BC3F28` references remain
- CSS compiles cleanly (`bun run build:css`)
- All 45 tests pass
- No new TypeScript errors introduced

## Test plan
- [ ] Visual check: Home, BusTracker, Explore, Ride, About pages in light mode
- [ ] Visual check: same pages in dark mode
- [ ] Verify WCAG AA contrast on body text (#2D3A20 on #FDFBD4)
- [ ] Check route-specific GTFS colors render well against new backgrounds
- [ ] PWA install: verify theme-color and background-color in manifest

https://claude.ai/code/session_011s9ZVhk3qgkrL6JHQy8AaC

---
_Generated by [Claude Code](https://claude.ai/code/session_011s9ZVhk3qgkrL6JHQy8AaC)_