### PR TITLE
Fix boarding badge alignment in rail view

### DIFF
--- a/src/views/pages/Rail.tsx
+++ b/src/views/pages/Rail.tsx
@@ -1270,16 +1270,18 @@ function railStyles(): string {
 
     /* Boarding — train at terminal, can board now */
     .rail-badge-boarding {
-      display: inline-block;
-      padding: 0.05rem 0.3rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.1rem 0.35rem;
       border-radius: 0.2rem;
-      font-size: 0.7rem;
+      font-size: 0.75rem;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.04em;
       background: #2d8a4e;
       color: #fff;
-      vertical-align: middle;
+      flex-shrink: 0;
     }
 
     .rail-empty {


### PR DESCRIPTION
## Summary
- Fix vertical misalignment of the "boarding" badge next to the route color pill in the rail station detail view
- The badge used `display: inline-block` with `vertical-align: middle` inside a flex container where `vertical-align` has no effect — switched to `inline-flex` and harmonized padding/sizing with the route color pill

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` passes (45 tests)
- [ ] Visual check: boarding badge should sit flush alongside the route color pill (e.g. "gold") without vertical offset

Fixes #60

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8vZVabhFXWQjwjszerzMD)_