### PR TITLE
Remove legacy PredictionUpdate type, fix isRailHost typing

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,13 +11,13 @@ import apiRoutes from "./routes/api.js";
 
 const RAIL_HOST = process.env.RAIL_HOST || ""; // e.g. "train.home.jake.town"
 
-type Env = {
+export type AppEnv = {
   Variables: {
     isRailHost: boolean;
   };
 };
 
-const app = new Hono<Env>();
+const app = new Hono<AppEnv>();
 
 // Host detection — set isRailHost for downstream routes
 app.use("*", async (c, next) => {

--- a/src/data/realtime.ts
+++ b/src/data/realtime.ts
@@ -21,18 +21,6 @@ interface VehiclePosition {
   staleSeconds: number;
 }
 
-// Legacy type — kept for backward compatibility. Identical to ArrivalPrediction.
-interface PredictionUpdate {
-  vehicleId?: string;
-  tripId?: string;
-  headsign?: string;
-  directionId?: number;
-  etaSeconds: number;
-  staleSeconds: number;
-  tier?: string;
-  adherenceSec?: number | null; // positive = late, negative = early, null = unknown
-}
-
 // Unified prediction type returned by findArrivals()
 interface ArrivalPrediction {
   vehicleId?: string;
@@ -486,7 +474,7 @@ export async function getVehicles(routeId: string, tripLookup: Map<string, Trip>
 }
 
 // Single-route predictions (no tier classification — use findArrivals directly for tiers)
-export async function getPredictions(routeId: string, stopId: string, tripLookup: Map<string, Trip>): Promise<PredictionUpdate[]> {
+export async function getPredictions(routeId: string, stopId: string, tripLookup: Map<string, Trip>): Promise<ArrivalPrediction[]> {
   return findArrivals({
     stopId,
     tripLookup,
@@ -495,7 +483,7 @@ export async function getPredictions(routeId: string, stopId: string, tripLookup
 }
 
 // Multi-route arrivals for a stop
-export interface StopArrival extends PredictionUpdate {
+export interface StopArrival extends ArrivalPrediction {
   routeId: string;
   routeShortName: string;
   routeColor: string;
@@ -542,4 +530,4 @@ export function isVehicleCacheWarm(): boolean {
   return realtimeService.isCacheWarm();
 }
 
-export type { VehiclePosition, PredictionUpdate, ArrivalPrediction };
+export type { VehiclePosition, ArrivalPrediction };

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,12 +1,13 @@
 import { Hono } from "hono";
+import type { AppEnv } from "../app.js";
 import { Layout } from "../views/Layout.js";
 import { AboutPage } from "../views/pages/About.js";
 import { aboutView as railAboutView } from "../rail/views.js";
 
-const app = new Hono();
+const app = new Hono<AppEnv>();
 
 app.get("/about", (c) => {
-  const isRailHost = (c.get as any)("isRailHost") || false;
+  const isRailHost = c.get("isRailHost") || false;
 
   if (isRailHost) {
     return c.html(railAboutView());

--- a/src/routes/rail.tsx
+++ b/src/routes/rail.tsx
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { AppEnv } from "../app.js";
 import { fetchArrivals, stationSlug, stationDisplayName } from "../rail/api.js";
 import {
   RailLandingPage,
@@ -9,13 +10,13 @@ import {
   RailTrainTimeline,
 } from "../views/pages/Rail.js";
 
-const app = new Hono();
+const app = new Hono<AppEnv>();
 
 // GET /rail — landing page (all stations)
 app.get("/rail", async (c) => {
   const arrivals = await fetchArrivals();
   const partial = c.req.query("partial");
-  const isRailHost = c.get("isRailHost" as any) || false;
+  const isRailHost = c.get("isRailHost") || false;
 
   if (partial === "1") {
     return c.html(<RailStationList arrivals={arrivals} />);
@@ -29,7 +30,7 @@ app.get("/rail/train/:trainId", async (c) => {
   const trainId = c.req.param("trainId");
   const arrivals = await fetchArrivals();
   const partial = c.req.query("partial");
-  const isRailHost = c.get("isRailHost" as any) || false;
+  const isRailHost = c.get("isRailHost") || false;
 
   if (partial === "1") {
     return c.html(<RailTrainTimeline trainId={trainId} arrivals={arrivals} />);
@@ -44,7 +45,7 @@ app.get("/rail/train/:trainId", async (c) => {
 app.get("/rail/:slug", async (c) => {
   const slug = c.req.param("slug");
   const arrivals = await fetchArrivals();
-  const isRailHost = c.get("isRailHost" as any) || false;
+  const isRailHost = c.get("isRailHost") || false;
 
   // Find matching station
   const stationArrivals = arrivals.filter(


### PR DESCRIPTION
## Summary
- Delete the legacy `PredictionUpdate` interface from `src/data/realtime.ts` (documented as identical to `ArrivalPrediction`, no external consumers)
- Update `getPredictions` return type and `StopArrival extends` clause to use `ArrivalPrediction`
- Export `AppEnv` type from `src/app.ts` so route sub-apps can inherit Hono's `Variables` typing
- Remove all `as any` casts in `src/routes/about.tsx` and `src/routes/rail.tsx` for `isRailHost` access

TypeScript-only changes — zero runtime behavior change.

Closes #63

---
_Generated by [Claude Code](https://claude.ai/code/session_015cvUHro5WRUGYLWzo8TQza)_