### PR TITLE
Eliminate duplicate data fetch on Stats page

### DIFF
--- a/src/routes/stats.tsx
+++ b/src/routes/stats.tsx
@@ -28,7 +28,15 @@ app.get("/stats", (c) => {
     );
   }
 
-  return c.html(<StatsPage />);
+  return c.html(
+    <StatsPage
+      snapshot={snapshot}
+      timeSeries={timeSeries}
+      routeSnapshots={routeSnapshots}
+      nameMap={nameMap}
+      hoursOfData={hoursOfData}
+    />
+  );
 });
 
 export default app;

--- a/src/views/pages/Stats.tsx
+++ b/src/views/pages/Stats.tsx
@@ -1,13 +1,7 @@
 // Stats dashboard — MARTA operational health
 // Hero: on-time performance. Secondary: delay, coverage, ghosts. SVG sparklines.
 
-import { getLatestSnapshot, getSystemTimeSeries, getLatestRouteSnapshots, type SystemSnapshot, type TimeSeriesPoint, type RouteSnapshot } from "../../data/metrics.js";
-import { getRoutes } from "../../data/db.js";
-
-function routeNameMap(): Map<string, string> {
-  const routes = getRoutes();
-  return new Map(routes.map(r => [r.route_id, r.route_short_name]));
-}
+import { type SystemSnapshot, type TimeSeriesPoint, type RouteSnapshot } from "../../data/metrics.js";
 
 // ── SVG Sparkline ──
 function Sparkline({ points, width = 600, height = 80, color = "#4A9FE5", label = "", unit = "", yMin, yMax }: {
@@ -123,16 +117,19 @@ function RouteTable({ routes, nameMap }: { routes: RouteSnapshot[]; nameMap: Map
 }
 
 // ── Main page ──
-export function StatsPage() {
-  const snapshot = getLatestSnapshot();
-  const timeSeries = getSystemTimeSeries(6);
-  const routeSnapshots = getLatestRouteSnapshots();
-  const nameMap = routeNameMap();
-
-  const firstTs = timeSeries.length > 0 ? timeSeries[0].ts : 0;
-  const lastTs = timeSeries.length > 0 ? timeSeries[timeSeries.length - 1].ts : 0;
-  const hoursOfData = ((lastTs - firstTs) / 3600).toFixed(1);
-
+export function StatsPage({
+  snapshot,
+  timeSeries,
+  routeSnapshots,
+  nameMap,
+  hoursOfData,
+}: {
+  snapshot: SystemSnapshot | null;
+  timeSeries: TimeSeriesPoint[];
+  routeSnapshots: RouteSnapshot[];
+  nameMap: Map<string, string>;
+  hoursOfData: string;
+}) {
   return (
     <html lang="en">
       <head>


### PR DESCRIPTION
## Summary
- **StatsPage** now accepts pre-fetched data as props instead of re-fetching internally, eliminating a duplicate call to `getLatestSnapshot()`, `getSystemTimeSeries()`, `getLatestRouteSnapshots()`, and `getRoutes()`
- Removes the now-unused `routeNameMap()` helper from `Stats.tsx`
- Partial-render path (`?partial=1`) is unchanged — it already used route-level data

## Test plan
- [x] `bunx tsc --noEmit` — no new type errors
- [x] `bun test` — all 27 tests pass
- [ ] Verify `/stats` full page load renders identically
- [ ] Verify `/stats?partial=1` polled refresh still works

Closes #70

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBvwQzMNhpJDxTLt3CUtyS)_