### PR TITLE
Remove invariant-dependent dead server code

### DIFF
--- a/docs/MARTA_WORKAROUNDS.md
+++ b/docs/MARTA_WORKAROUNDS.md
@@ -46,7 +46,7 @@ For every `active`-tier prediction (bus confirmed on this trip via GPS), we comp
 3. Sum the scheduled inter-stop travel times from there to the target stop
 4. Adjust for how ahead/behind schedule the bus is at its current position
 
-This GPS-based ETA replaces MARTA's prediction. We keep MARTA's original as `martaEtaSeconds` for comparison.
+This GPS-based ETA replaces MARTA's prediction.
 
 ### Results
 **Round 1 (Route 21, 1 stop, Feb 17–21):**

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -178,20 +178,11 @@ class MARTADatabase {
 
   // Get single stop
   getStop(stopId: string): Stop | null {
-    try {
-      return this.db.prepare(`
-        SELECT stop_id, stop_name, stop_lat, stop_lon, nearest_rail_station, nearest_rail_distance_m
-        FROM stops 
-        WHERE stop_id = ?
-      `).get(stopId) as Stop | null;
-    } catch {
-      // Fallback if transfer columns don't exist yet
-      return this.db.prepare(`
-        SELECT stop_id, stop_name, stop_lat, stop_lon
-        FROM stops 
-        WHERE stop_id = ?
-      `).get(stopId) as Stop | null;
-    }
+    return this.db.prepare(`
+      SELECT stop_id, stop_name, stop_lat, stop_lon, nearest_rail_station, nearest_rail_distance_m
+      FROM stops
+      WHERE stop_id = ?
+    `).get(stopId) as Stop | null;
   }
 
   // Get all stop IDs in the same group (paired directional stops at same location).

--- a/src/data/gtfs-import.ts
+++ b/src/data/gtfs-import.ts
@@ -54,14 +54,6 @@ class GTFSImporter {
       )
     `);
 
-    // Add service_id column if upgrading from old schema
-    try {
-      this.db.exec(`ALTER TABLE trips ADD COLUMN service_id TEXT`);
-      console.log("  ↳ Added service_id column to trips");
-    } catch (_) {
-      // Column already exists
-    }
-
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS shapes (
         shape_id TEXT,
@@ -450,7 +442,6 @@ class GTFSImporter {
 
     // Rebuild derived tables
     this.buildRouteStops();
-    this.buildStopGroups();
   }
 
   buildTransferLookup() {

--- a/src/data/metrics.ts
+++ b/src/data/metrics.ts
@@ -6,8 +6,6 @@ import { Database } from "bun:sqlite";
 import path from "path";
 import { getTripLookup, getRoutes } from "./db";
 import { getAllVehicles, isVehicleCacheWarm, type VehiclePosition } from "./realtime";
-// Rail sampling paused — no good KPI yet
-// import { fetchArrivals as fetchRailArrivals, isRailCacheWarm } from "../rail/api";
 import { parseTimeToSec, type TripStop } from "./eta";
 
 const DB_PATH = process.env.DATABASE_URL || path.join(process.cwd(), "data", "marta.db");
@@ -316,48 +314,6 @@ async function sampleBusMetrics(): Promise<RouteSample[]> {
   return samples;
 }
 
-// ─── Rail sampling (unchanged) ───
-
-interface RailSample {
-  line: string;
-  trains: number;
-  avgDelaySec: number;
-  realtimeCount: number;
-  scheduledCount: number;
-}
-
-async function sampleRailMetrics(): Promise<RailSample[]> {
-  let arrivals;
-  try {
-    arrivals = await fetchRailArrivals();
-  } catch {
-    return [];
-  }
-
-  const byLine = new Map<string, { trains: Set<string>; totalWait: number; count: number; realtime: number; scheduled: number }>();
-
-  for (const a of arrivals) {
-    let line = byLine.get(a.line);
-    if (!line) {
-      line = { trains: new Set(), totalWait: 0, count: 0, realtime: 0, scheduled: 0 };
-      byLine.set(a.line, line);
-    }
-    line.trains.add(a.trainId);
-    line.totalWait += a.waitSeconds;
-    line.count++;
-    if (a.isRealtime) line.realtime++;
-    else line.scheduled++;
-  }
-
-  return Array.from(byLine.entries()).map(([lineName, data]) => ({
-    line: lineName,
-    trains: data.trains.size,
-    avgDelaySec: data.count > 0 ? data.totalWait / data.count : 0,
-    realtimeCount: data.realtime,
-    scheduledCount: data.scheduled,
-  }));
-}
-
 // ─── Collection orchestrator ───
 
 export async function collectMetrics(): Promise<void> {
@@ -376,8 +332,6 @@ export async function collectMetrics(): Promise<void> {
 
   try {
     const busSamples = await sampleBusMetrics();
-    // Rail sampling paused — no good KPI yet. Re-enable when we find one.
-    const railSamples: RailSample[] = [];
 
     const insert = db.prepare(
       `INSERT INTO metrics (ts, kind, route_id, vehicles, ghost_count, avg_delay_sec, trips_active, trips_scheduled, on_time_count)
@@ -412,21 +366,6 @@ export async function collectMetrics(): Promise<void> {
       // System summary
       const sysAvgDelay = systemDelayCount > 0 ? systemDelay / systemDelayCount : null;
       insert.run(ts, "system", null, totalVehicles, totalGhosts, sysAvgDelay, totalActive, totalScheduled, totalOnTime || null);
-
-      // Rail
-      let totalTrains = 0;
-      for (const s of railSamples) {
-        insert.run(ts, "rail", s.line, s.trains, null,
-          s.avgDelaySec, s.realtimeCount, s.scheduledCount, null);
-        totalTrains += s.trains;
-      }
-
-      if (railSamples.length > 0) {
-        const avgWait = railSamples.reduce((sum, s) => sum + s.avgDelaySec, 0) / railSamples.length;
-        const totalRealtime = railSamples.reduce((sum, s) => sum + s.realtimeCount, 0);
-        const totalScheduledRail = railSamples.reduce((sum, s) => sum + s.scheduledCount, 0);
-        insert.run(ts, "rail-system", null, totalTrains, null, avgWait, totalRealtime, totalScheduledRail, null);
-      }
     });
 
     tx();
@@ -440,9 +379,8 @@ export async function collectMetrics(): Promise<void> {
     const coverage = busScheduled > 0 ? ((busVehicles / busScheduled) * 100).toFixed(0) : "?";
     const avgDelay = busSamples.reduce((s, r) => s + r.totalDelaySec, 0);
     const delayStr = delayN > 0 ? `${(avgDelay / delayN / 60).toFixed(1)}min avg` : "no delay data";
-    const trains = railSamples.reduce((s, r) => s + r.trains, 0);
 
-    console.log(`📊 Metrics: ${busOnTime}/${delayN} on-time (${onTimePct}%), ${busVehicles}/${busScheduled} coverage (${coverage}%), ${delayStr}, ${trains} trains`);
+    console.log(`📊 Metrics: ${busOnTime}/${delayN} on-time (${onTimePct}%), ${busVehicles}/${busScheduled} coverage (${coverage}%), ${delayStr}`);
   } catch (err) {
     console.error("📊 Metrics collection failed:", err);
   }

--- a/src/data/realtime.ts
+++ b/src/data/realtime.ts
@@ -44,7 +44,6 @@ interface ArrivalPrediction {
   tier?: string;
   adherenceSec?: number | null;
   etaSource?: 'marta' | 'computed' | 'scheduled'; // 'computed' = GPS interpolation, 'scheduled' = GTFS static (terminal vehicles)
-  martaEtaSeconds?: number; // original MARTA ETA before computed override (for comparison)
   rescued?: boolean; // true = ghost vehicle rescue (no valid MARTA trip update existed)
   atTerminal?: boolean; // true = vehicle at first stop, waiting to depart
   // Route enrichment — present when routeInfo provided
@@ -385,7 +384,7 @@ async function findArrivals(opts: FindArrivalsOptions): Promise<ArrivalPredictio
 
   // Unified active-tier ETA: for ALL vehicles with GPS positions, compute ETA from
   // vehicle position + scheduled inter-stop deltas. Updates existing MARTA predictions
-  // (preserving martaEtaSeconds) or synthesizes new ones for ghost vehicles (rescued: true).
+  // or synthesizes new ones for ghost vehicles (rescued: true).
   if (vehicles && vehicles.length > 0) {
     const existingByTrip = new Map(
       arrivals.filter(a => a.tripId).map(a => [a.tripId!, a])
@@ -424,7 +423,6 @@ async function findArrivals(opts: FindArrivalsOptions): Promise<ArrivalPredictio
 
       if (existing && existing.tier === 'active') {
         // Override existing MARTA prediction with computed/scheduled ETA
-        existing.martaEtaSeconds = existing.etaSeconds;
         existing.etaSeconds = eta;
         existing.etaSource = source;
         if (atTerminal) existing.atTerminal = true;


### PR DESCRIPTION
## Summary
- **metrics.ts**: Remove dead rail sampling code — `sampleRailMetrics()`, `RailSample` interface, commented-out import, hardcoded empty `railSamples`, rail insert loop, and trailing `trains` reduce/log (all unreachable since `fetchRailArrivals` import was commented out)
- **realtime.ts**: Remove write-only `martaEtaSeconds` field (set but never read) and its doc reference
- **db.ts**: Simplify `getStop()` by removing unreachable try/catch fallback — migrations run before server bind, so transfer columns are guaranteed
- **gtfs-import.ts**: Remove redundant `buildStopGroups()` call in `cleanExpiredServices` and legacy `ALTER TABLE trips ADD COLUMN service_id` shim

Net: -82 lines of provably dead code.

## Test plan
- [x] `bunx tsc --noEmit` — no new type errors
- [x] `bun test` — all 27 tests pass
- [ ] Verify `/api/nearby` still returns stops with distance
- [ ] Verify metrics collection still logs correctly

Closes #65

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBvwQzMNhpJDxTLt3CUtyS)_