### PR TITLE
Mechanical dead-code and simplification sweep

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -16,7 +16,6 @@ class PullcordApp {
     this.lastPredictions = [];
     this.lastVehicles = [];
     this.heroEtaSeconds = null;
-    this.heroVehicleId = null;
     this.heroPrediction = null;
 
     // Countdown timer (ticks every second between polls)
@@ -742,7 +741,6 @@ class PullcordApp {
     }
     this.heroPrediction = hero;
     this.heroEtaSeconds = hero.etaSeconds;
-    this.heroVehicleId = hero.vehicleId;
 
     this.renderHeroDisplay();
     this.startCountdown();
@@ -776,7 +774,7 @@ class PullcordApp {
 
     if (isArriving) {
       // Show seconds countdown for last minute
-      numEl.textContent = seconds < 30 ? 'NOW' : `<1`;
+      numEl.textContent = seconds < 30 ? 'NOW' : '<1';
       unitEl.textContent = seconds < 30 ? '' : 'min';
     } else if (this.heroPrediction.atTerminal) {
       numEl.textContent = `${minutes}+`;
@@ -877,20 +875,19 @@ class PullcordApp {
   renderProgressStrip(predictions, vehicles) {
     const section = document.getElementById('progress-section');
     const strip = document.getElementById('progress-strip');
-    const label = document.getElementById('progress-label');
     if (!section || !strip) return;
 
     // Use the current hero prediction (respects tracked vehicle / direction)
     const hero = this.heroPrediction;
     if (!hero || hero.tier === 'scheduled' || hero.tier === 'next' || !hero.vehicleId) {
-      this.renderEmptyStrip(strip, label);
+      this.renderEmptyStrip(strip);
       return;
     }
 
     // Find the vehicle
     const vehicle = vehicles.find(v => v.id === hero.vehicleId || v.vehicleId === hero.vehicleId);
     if (!vehicle) {
-      this.renderEmptyStrip(strip, label);
+      this.renderEmptyStrip(strip);
       return;
     }
 
@@ -912,13 +909,13 @@ class PullcordApp {
     }
 
     if (bestDir === null || bestMyIdx < 0 || bestBusIdx < 0) {
-      this.renderEmptyStrip(strip, label);
+      this.renderEmptyStrip(strip);
       return;
     }
 
     const stops = this.dirStops[bestDir];
     const n = stops.length;
-    if (n < 2) { this.renderEmptyStrip(strip, label); return; }
+    if (n < 2) { this.renderEmptyStrip(strip); return; }
 
     // Calculate bus fractional position between stops
     let busFrac = 0;
@@ -1001,7 +998,7 @@ class PullcordApp {
   }
 
   // Empty progress strip — reserves space, shows just the track line
-  renderEmptyStrip(strip, label) {
+  renderEmptyStrip(strip) {
     if (!strip) return;
     const w = strip.clientWidth || 340;
     const h = 40;
@@ -1013,7 +1010,6 @@ class PullcordApp {
     strip.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">` +
       `<line x1="${pad}" y1="${lineY}" x2="${w-pad}" y2="${lineY}" stroke="${stripLine}" stroke-width="2" stroke-linecap="round"/>` +
       `</svg>`;
-    if (label) label.textContent = '';
   }
 
   // ─────────────────────────────
@@ -1477,7 +1473,6 @@ class PullcordApp {
   initMapToggle() {
     const toggleBtn = document.getElementById('map-toggle-btn');
     const closeBtn = document.getElementById('map-close-btn');
-    const toggleText = document.getElementById('map-toggle-text');
 
     if (toggleBtn) toggleBtn.addEventListener('click', () => {
       // Live hero → navigate to ride view
@@ -1689,12 +1684,6 @@ class PullcordApp {
   renderRouteTabs(current, others) {
     const container = document.getElementById('route-tabs');
     if (!container) return;
-
-    // Only show tabs if there ARE other routes — no need to show just the current one
-    if (others.length === 0) {
-      container.innerHTML = '';
-      return;
-    }
 
     const basePath = window.__BASE_PATH__ || '';
     const stopId = this.config.stopId;

--- a/public/explore.js
+++ b/public/explore.js
@@ -162,9 +162,6 @@
       markers.push(marker);
     });
 
-    if (stops.length > limit) {
-      console.log(`Showing ${limit}/${stops.length} stops (zoom in for more)`);
-    }
   }
 
   function renderClusters(stops, zoom) {

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -52,6 +52,7 @@ const RAIL_ROUTES = new Set(['BLUE', 'GREEN', 'RED', 'GOLD']);
 class MARTADatabase {
   public db: Database;
   private tripLookupCache: Map<string, Trip> | null = null;
+  private _allStopsCache: { stops: any[]; cachedAt: number } | null = null;
 
   constructor() {
     // Migrations run separately in index.ts before server start.
@@ -386,8 +387,6 @@ class MARTADatabase {
   // Get all bus stops with routes (for explore map)
   // Returns deduplicated stops with comma-separated route short names
   // Cached — this query is expensive but data rarely changes
-  private _allStopsCache: { stops: any[]; cachedAt: number } | null = null;
-  
   getAllStopsWithRoutes(): { stop_id: string; stop_name: string; stop_lat: number; stop_lon: number; routes: string }[] {
     // Cache for 1 hour
     if (this._allStopsCache && Date.now() - this._allStopsCache.cachedAt < 3600000) {
@@ -426,7 +425,7 @@ export function getStopsForRoute(routeId: string, limit?: number): Stop[] {
   return db.getStopsForRoute(routeId, limit);
 }
 
-export function getNearbyStops(lat: number, lon: number, radiusMeters?: number, limit?: number): Stop[] {
+export function getNearbyStops(lat: number, lon: number, radiusMeters?: number, limit?: number): (Stop & { distance: number })[] {
   return db.getNearbyStops(lat, lon, radiusMeters, limit);
 }
 

--- a/src/rail/api.ts
+++ b/src/rail/api.ts
@@ -124,11 +124,6 @@ async function _refresh(): Promise<RailArrival[]> {
   return data;
 }
 
-// True if rail data was recently fetched successfully.
-export function isRailCacheWarm(): boolean {
-  return cache?.kind === "ok" && Date.now() - cache.ts < 5 * 60 * 1000;
-}
-
 // Current cached error message, or null if the last cached result was a success
 // (or there's no cache yet).
 export function getRailApiError(): string | null {
@@ -151,18 +146,3 @@ export function stationDisplayName(name: string): string {
     .join(" ");
 }
 
-// Group arrivals by station
-export function byStation(arrivals: RailArrival[]): Map<string, RailArrival[]> {
-  const map = new Map<string, RailArrival[]>();
-  for (const a of arrivals) {
-    const list = map.get(a.station) || [];
-    list.push(a);
-    map.set(a.station, list);
-  }
-  return map;
-}
-
-// Lines that serve a station
-export function stationLines(arrivals: RailArrival[]): Set<string> {
-  return new Set(arrivals.map((a) => a.line));
-}

--- a/src/routes/rail.tsx
+++ b/src/routes/rail.tsx
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../app.js";
-import { fetchArrivals, stationSlug, stationDisplayName } from "../rail/api.js";
+import { fetchArrivals, stationSlug } from "../rail/api.js";
 import {
   RailLandingPage,
   RailStationList,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -549,13 +549,6 @@
     min-height: 1.4em;
   }
 
-  .d-progress-meta {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 0.5rem;
-  }
-
   /* ──────────────────────────────────
      PROGRESS STRIP — linear route viz
      ────────────────────────────────── */
@@ -572,14 +565,6 @@
 
   .d-progress-strip svg {
     display: block;
-  }
-
-  .d-progress-label {
-    text-align: center;
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--text-secondary);
-    padding: 0.5rem 0 0;
   }
 
 

--- a/src/views/pages/BusTracker.tsx
+++ b/src/views/pages/BusTracker.tsx
@@ -79,9 +79,6 @@ export const BusTrackerPage = (props: BusTrackerPageProps) => {
         {/* PROGRESS STRIP */}
         <section class="d-progress" id="progress-section">
           <div class="d-progress-strip" id="progress-strip"></div>
-          <div class="d-progress-meta">
-            <div class="d-progress-label" id="progress-label"></div>
-          </div>
         </section>
 
         {/* UPCOMING — remaining predictions */}

--- a/src/views/pages/Rail.tsx
+++ b/src/views/pages/Rail.tsx
@@ -16,18 +16,10 @@ function RailApiBanner() {
 
 // ── Accessible line colors ──
 const LINE_COLORS = {
-  dark: {
-    RED: "#E05555",
-    GOLD: "#D4A020",
-    BLUE: "#4A9FE5",
-    GREEN: "#3BAA6E",
-  },
-  light: {
-    RED: "#B33030",
-    GOLD: "#8B6D14",
-    BLUE: "#1A6BB5",
-    GREEN: "#1B7A45",
-  },
+  RED: "#E05555",
+  GOLD: "#D4A020",
+  BLUE: "#4A9FE5",
+  GREEN: "#3BAA6E",
 };
 
 // ── Station orderings for train timeline (north→south per line) ──
@@ -248,14 +240,6 @@ reorder();
   return base + landing;
 }
 
-// Map direction codes to short labels
-const DIR_LABELS: Record<string, string> = {
-  N: "N",
-  S: "S",
-  E: "E",
-  W: "W",
-};
-
 // Canonical station order — alphabetical for landing page
 const STATION_ORDER = [
   "AIRPORT STATION",
@@ -377,11 +361,10 @@ function buildStationRows(arrivals: RailArrival[]): StationRow[] {
 }
 
 // ── Pill component ──
-function Pill({ pill, mode = "dark" }: { pill: StationPill; mode?: "dark" | "light" }) {
-  const colors = LINE_COLORS[mode];
-  const bg = colors[pill.line as keyof typeof colors] || "#666";
+function Pill({ pill }: { pill: StationPill }) {
+  const bg = LINE_COLORS[pill.line as keyof typeof LINE_COLORS] || "#666";
   const isNow = pill.waitSeconds < 60;
-  const label = `${DIR_LABELS[pill.direction] || pill.direction} ${formatTime(pill.waitSeconds)}`;
+  const label = `${pill.direction} ${formatTime(pill.waitSeconds)}`;
 
   return (
     <span
@@ -395,7 +378,7 @@ function Pill({ pill, mode = "dark" }: { pill: StationPill; mode?: "dark" | "lig
 }
 
 // ── Four-direction pill grid (Five Points) ──
-function FourPillGrid({ pills, mode = "dark" }: { pills: StationPill[]; mode?: "dark" | "light" }) {
+function FourPillGrid({ pills }: { pills: StationPill[] }) {
   const byDir = new Map(pills.map((p) => [p.direction, p]));
   const grid = [
     ["N", "E"],
@@ -407,7 +390,7 @@ function FourPillGrid({ pills, mode = "dark" }: { pills: StationPill[]; mode?: "
       {grid.flat().map((dir) => {
         const p = byDir.get(dir);
         return p ? (
-          <Pill pill={p} mode={mode} />
+          <Pill pill={p} />
         ) : (
           <span class="rail-pill rail-pill-empty">—</span>
         );
@@ -417,7 +400,7 @@ function FourPillGrid({ pills, mode = "dark" }: { pills: StationPill[]; mode?: "
 }
 
 // ── Station row ──
-function StationRowEl({ row, mode = "dark" }: { row: StationRow; mode?: "dark" | "light" }) {
+function StationRowEl({ row }: { row: StationRow }) {
   return (
     <a href={`/rail/${row.slug}`} class="rail-row" aria-label={`${row.name} station`}>
       <span class="rail-station-name">{row.name.toLowerCase()}</span>
@@ -425,11 +408,11 @@ function StationRowEl({ row, mode = "dark" }: { row: StationRow; mode?: "dark" |
         {row.pills.length === 0 ? (
           <span class="rail-no-data">—</span>
         ) : row.isFourDir ? (
-          <FourPillGrid pills={row.pills} mode={mode} />
+          <FourPillGrid pills={row.pills} />
         ) : (
           <span class="rail-pills-inline">
             {row.pills.map((p) => (
-              <Pill pill={p} mode={mode} />
+              <Pill pill={p} />
             ))}
           </span>
         )}
@@ -586,12 +569,11 @@ export function RailStationDetail({
   arrivals: RailArrival[];
 }) {
   const sorted = [...arrivals].sort((a, b) => a.waitSeconds - b.waitSeconds);
-  const colors = LINE_COLORS.dark;
 
   return (
     <div class="rail-detail-list">
       {sorted.map((a) => {
-        const bg = colors[a.line as keyof typeof colors] || "#666";
+        const bg = LINE_COLORS[a.line as keyof typeof LINE_COLORS] || "#666";
         const isNow = a.waitSeconds < 60;
         const isScheduled = !a.isRealtime;
         const isBoarding = a.isRealtime && !a.hasStarted && a.isFirstStop;
@@ -640,7 +622,7 @@ export function RailTrainPage({
   const hasData = trainArrivals.length > 0;
   const line = hasData ? trainArrivals[0].line : "";
   const destination = hasData ? stationDisplayName(trainArrivals[0].destination) : "Unknown";
-  const color = hasData ? (LINE_COLORS.dark[line as keyof typeof LINE_COLORS["dark"]] || "#666") : "#666";
+  const color = hasData ? (LINE_COLORS[line as keyof typeof LINE_COLORS] || "#666") : "#666";
 
   const title = standalone
     ? `Train ${trainId} — marta.io rail`
@@ -747,7 +729,7 @@ export function RailTrainTimeline({
 
   const line = trainArrivals[0].line;
   const direction = trainArrivals[0].direction;
-  const color = LINE_COLORS.dark[line as keyof typeof LINE_COLORS["dark"]] || "#666";
+  const color = LINE_COLORS[line as keyof typeof LINE_COLORS] || "#666";
 
   // Build ordered stop list from API data, using LINE_STATIONS for sort order
   const lineOrder = LINE_STATIONS[line] || [];


### PR DESCRIPTION
## Summary
- **app.js**: Remove write-only `heroVehicleId`, unused `toggleText`, dead progress-label plumbing (incl. BusTracker.tsx div + CSS rules), unreachable `others.length === 0` guard, and backtick→plain string fix
- **explore.js**: Remove debug `console.log` for marker truncation
- **Rail.tsx**: Flatten `LINE_COLORS` (remove dead `light` branch), remove always-`"dark"` `mode` prop from `Pill`/`FourPillGrid`/`StationRowEl`, delete identity-map `DIR_LABELS`
- **rail/api.ts**: Delete unused exports `isRailCacheWarm`, `byStation`, `stationLines`
- **routes/rail.tsx**: Remove unused `stationDisplayName` import
- **db.ts**: Widen `getNearbyStops` return type to include `distance`, move `_allStopsCache` field declaration next to other cache fields

Net: -71 lines across 8 files. All changes are dead code removal or simplification — no behavioral changes.

## Test plan
- [x] `bunx tsc --noEmit` — no new type errors
- [x] `bun test` — all 27 tests pass
- [x] `bun run build:css` — succeeds
- [ ] Verify hero countdown, route tabs, explore markers, and rail view render unchanged

Closes #62

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBvwQzMNhpJDxTLt3CUtyS)_