### PR TITLE
Dedupe server helpers: distSq, GTFS pipeline, group_id SQL

### DIFF
--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -54,6 +54,12 @@ class MARTADatabase {
   private tripLookupCache: Map<string, Trip> | null = null;
   private _allStopsCache: { stops: any[]; cachedAt: number } | null = null;
 
+  // SQL subquery: all stop_ids sharing the same group_id as the given stop.
+  // Parameterised with one `?` placeholder bound to the input stop_id.
+  private groupIdSubquery(): string {
+    return `SELECT stop_id FROM stops WHERE group_id = (SELECT group_id FROM stops WHERE stop_id = ?)`;
+  }
+
   constructor() {
     // Migrations run separately in index.ts before server start.
     // By the time this constructor runs, schema is guaranteed current.
@@ -191,7 +197,7 @@ class MARTADatabase {
   getStopIdsByName(stopId: string): string[] {
     const ids = this.db.prepare(`
       SELECT stop_id FROM stops
-      WHERE group_id = (SELECT group_id FROM stops WHERE stop_id = ?)
+      WHERE stop_id IN (${this.groupIdSubquery()})
     `).all(stopId) as Array<{ stop_id: string }>;
     return ids.length > 0 ? ids.map(r => r.stop_id) : [stopId];
   }
@@ -203,10 +209,7 @@ class MARTADatabase {
       SELECT DISTINCT r.route_id, r.route_short_name, r.route_long_name, r.route_color, r.route_text_color
       FROM routes r
       JOIN route_stops rs ON r.route_id = rs.route_id
-      WHERE rs.stop_id IN (
-        SELECT stop_id FROM stops
-        WHERE group_id = (SELECT group_id FROM stops WHERE stop_id = ?)
-      )
+      WHERE rs.stop_id IN (${this.groupIdSubquery()})
       ORDER BY CAST(r.route_short_name AS INTEGER), r.route_short_name
     `).all(stopId) as Route[];
     return routes.filter(r => !RAIL_ROUTES.has(r.route_short_name));
@@ -341,12 +344,10 @@ class MARTADatabase {
     if (tripIds.length === 0) return new Map();
     const tripPlaceholders = tripIds.map(() => '?').join(',');
     const rows = this.db.prepare(`
-      SELECT trip_id, arrival_time 
-      FROM stop_times 
-      WHERE stop_id IN (
-        SELECT stop_id FROM stops
-        WHERE group_id = (SELECT group_id FROM stops WHERE stop_id = ?)
-      ) AND trip_id IN (${tripPlaceholders})
+      SELECT trip_id, arrival_time
+      FROM stop_times
+      WHERE stop_id IN (${this.groupIdSubquery()})
+        AND trip_id IN (${tripPlaceholders})
     `).all(stopId, ...tripIds) as Array<{ trip_id: string; arrival_time: string }>;
     const result = new Map<string, string>();
     for (const row of rows) {

--- a/src/data/eta.ts
+++ b/src/data/eta.ts
@@ -20,7 +20,7 @@ export function parseTimeToSec(time: string): number {
 /**
  * Squared distance between two points (for comparison only — avoids sqrt).
  */
-function distSq(lat1: number, lon1: number, lat2: number, lon2: number): number {
+export function distSq(lat1: number, lon1: number, lat2: number, lon2: number): number {
   const dLat = lat2 - lat1;
   const dLon = (lon2 - lon1) * Math.cos(((lat1 + lat2) / 2) * Math.PI / 180);
   return dLat * dLat + dLon * dLon;

--- a/src/data/gtfs-import.ts
+++ b/src/data/gtfs-import.ts
@@ -519,6 +519,19 @@ class GTFSImporter {
     console.log(`🚇 ${count} bus stops linked to ${stations.size} rail stations (${RADIUS_M}m radius)`);
   }
 
+  async runFullImport() {
+    await this.importRoutes();
+    await this.importStops(); // includes atomic group_id assignment
+    await this.importCalendar();
+    await this.importCalendarDates();
+    await this.importTrips();
+    await this.importShapes();
+    await this.importStopTimes();
+    this.buildRouteStops();
+    this.cleanExpiredServices();
+    this.buildTransferLookup();
+  }
+
   printStats() {
     console.log("\n📊 DATABASE STATISTICS");
     console.log("======================");
@@ -554,17 +567,7 @@ async function main() {
   const importer = new GTFSImporter();
 
   try {
-    await importer.importRoutes();
-    await importer.importStops(); // includes atomic group_id assignment
-    await importer.importCalendar();
-    await importer.importCalendarDates();
-    await importer.importTrips();
-    await importer.importShapes();
-    await importer.importStopTimes();
-    importer.buildRouteStops();
-    importer.cleanExpiredServices();
-    importer.buildTransferLookup();
-
+    await importer.runFullImport();
     importer.printStats();
 
     console.log("\n✅ GTFS import complete!");
@@ -616,16 +619,7 @@ export async function refreshGTFS() {
   // Run import
   const importer = new GTFSImporter();
   try {
-    await importer.importRoutes();
-    await importer.importStops(); // includes atomic group_id assignment
-    await importer.importCalendar();
-    await importer.importCalendarDates();
-    await importer.importTrips();
-    await importer.importShapes();
-    await importer.importStopTimes();
-    importer.buildRouteStops();
-    importer.cleanExpiredServices();
-    importer.buildTransferLookup();
+    await importer.runFullImport();
     importer.printStats();
     console.log("✅ GTFS refresh complete!");
   } catch (error) {

--- a/src/data/metrics.ts
+++ b/src/data/metrics.ts
@@ -6,7 +6,7 @@ import { Database } from "bun:sqlite";
 import path from "path";
 import { getTripLookup, getRoutes } from "./db";
 import { getAllVehicles, isVehicleCacheWarm, type VehiclePosition } from "./realtime";
-import { parseTimeToSec, type TripStop } from "./eta";
+import { distSq, parseTimeToSec, type TripStop } from "./eta";
 
 const DB_PATH = process.env.DATABASE_URL || path.join(process.cwd(), "data", "marta.db");
 const SAMPLE_INTERVAL = 5 * 60 * 1000; // 5 minutes
@@ -26,14 +26,6 @@ function getDb(): Database {
     metricsDb.exec("PRAGMA journal_mode=WAL");
   }
   return metricsDb;
-}
-
-// ─── Spatial math (same as eta.ts, not exported there) ───
-
-function distSq(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const dLat = lat2 - lat1;
-  const dLon = (lon2 - lon1) * Math.cos(((lat1 + lat2) / 2) * Math.PI / 180);
-  return dLat * dLat + dLon * dLon;
 }
 
 // ─── Time helpers ───


### PR DESCRIPTION
## Summary
- **Export `distSq` from `eta.ts`**, import in `metrics.ts` — eliminates byte-identical duplicate
- **Extract `runFullImport()`** in `gtfs-import.ts` — consolidates the 10-step import sequence shared by `main()` and `refreshGTFS()`, preserving each caller's distinct error handling
- **Add `groupIdSubquery()` helper** in `db.ts` — DRYs up the paired-stop SQL fragment used in 3 queries (self-join variant left as-is)

Net: 4 files changed, 29 insertions, 42 deletions.

Closes #66

## Test plan
- [x] `bun test` — all 27 tests pass
- [x] `bunx tsc --noEmit` — type check passes
- [x] `public/eta.js` left untouched (separate browser runtime)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLuF6RurAyifRN8XZhig5n)_