### PR TITLE
Improve bus stop map tap targets with zoom-dependent radius

### DIFF
--- a/public/explore.js
+++ b/public/explore.js
@@ -142,6 +142,13 @@
     }
   }
 
+  function getStopRadius(zoom) {
+    if (zoom <= 15) return 7;
+    if (zoom <= 16) return 10;
+    if (zoom <= 17) return 13;
+    return 16;
+  }
+
   function renderIndividual(stops) {
     // Limit to avoid DOM overload
     const limit = 500;
@@ -149,7 +156,7 @@
 
     toRender.forEach(stop => {
       const marker = L.circleMarker([stop.stop_lat, stop.stop_lon], {
-        radius: 6,
+        radius: getStopRadius(map.getZoom()),
         fillColor: '#E85D3A',
         fillOpacity: 0.85,
         color: '#fff',

--- a/public/ride.js
+++ b/public/ride.js
@@ -129,7 +129,7 @@
     stops.forEach((stop, i) => {
       const isDest = i === destIndex;
       const marker = L.circleMarker([stop.lat, stop.lon], {
-        radius: isDest ? 9 : 5,
+        radius: isDest ? 10 : 8,
         fillColor: isDest ? '#3B82F6' : routeColor,
         fillOpacity: isDest ? 1 : 0.7,
         color: '#fff',


### PR DESCRIPTION
## Summary

Closes #79. Bus stop circle markers on the Explore and Ride maps were too small to comfortably tap on mobile (6px and 5px radius respectively — well below the 44px touch target guideline).

- **Explore map** (`explore.js`): Added `getStopRadius(zoom)` helper that scales markers from 7px (zoom 15, many stops visible) up to 16px (zoom 18+, few stops, finger-friendly). The map already re-renders markers on every zoom change so this is zero-overhead.
- **Ride map** (`ride.js`): Bumped non-destination stops from 5→8px and destination from 9→10px for better tap targets while maintaining visual distinction.

## Test plan

- [x] All 27 existing tests pass
- [ ] Verify explore map markers grow as you zoom in (zoom 15→18)
- [ ] Verify ride map stop dots are comfortably tappable on mobile
- [ ] Check that markers don't overlap excessively at high zoom with dense stops

---
_Generated by [Claude Code](https://claude.ai/code/session_016qro8HV4wqNZZTNLArCJFp)_