### PR TITLE
Shared error page, cache-bust all scripts, move /api/rail

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -145,6 +145,8 @@ app.get("/health", (c) => {
 });
 
 // Error handling
+import { ErrorPage } from "./views/pages/ErrorPage.js";
+
 app.onError((err, c) => {
   console.error("Application error:", err);
 
@@ -160,31 +162,16 @@ app.onError((err, c) => {
     );
   }
 
+  const message = process.env.NODE_ENV === "development"
+    ? `We're sorry, but an error occurred: ${err.message}`
+    : "We're sorry, but an error occurred while processing your request.";
+
   return c.html(
-    `
-    <html>
-      <head>
-        <title>Error — Pullcord</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <style>
-          body { font-family: system-ui; text-align: center; padding: 50px; background: #f9fafb; }
-          .error { max-width: 400px; margin: 0 auto; }
-          h1 { color: #ef4444; }
-          p { color: #6b7280; margin: 20px 0; }
-          a { color: #2563eb; text-decoration: none; }
-          a:hover { text-decoration: underline; }
-        </style>
-      </head>
-      <body>
-        <div class="error">
-          <h1>Something went wrong</h1>
-          <p>We're sorry, but an error occurred while processing your request.</p>
-          ${process.env.NODE_ENV === "development" ? `<p><code>${err.message}</code></p>` : ""}
-          <p><a href="/">← Back to Home</a></p>
-        </div>
-      </body>
-    </html>
-  `,
+    <ErrorPage
+      title="Error — Pullcord"
+      heading="Something went wrong"
+      message={message}
+    />,
     500,
   );
 });
@@ -196,29 +183,11 @@ app.notFound((c) => {
   }
 
   return c.html(
-    `
-    <html>
-      <head>
-        <title>Not Found — Pullcord</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <style>
-          body { font-family: system-ui; text-align: center; padding: 50px; background: #f9fafb; }
-          .error { max-width: 400px; margin: 0 auto; }
-          h1 { color: #6b7280; }
-          p { color: #6b7280; margin: 20px 0; }
-          a { color: #2563eb; text-decoration: none; }
-          a:hover { text-decoration: underline; }
-        </style>
-      </head>
-      <body>
-        <div class="error">
-          <h1>Page not found</h1>
-          <p>The page you're looking for doesn't exist.</p>
-          <p><a href="/">← Back to Home</a></p>
-        </div>
-      </body>
-    </html>
-  `,
+    <ErrorPage
+      title="Not Found — Pullcord"
+      heading="Page not found"
+      message="The page you're looking for doesn't exist."
+    />,
     404,
   );
 });

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -4,6 +4,7 @@ import { getVehicles, findArrivals, getStopArrivals } from "../data/realtime.js"
 import { getMockVehicles, getMockPredictions } from "../data/mock.js";
 import { getVapidPublicKey, registerCord, cancelCord, cordExists, getActiveCordCount } from "../data/push.js";
 import { getLatestSnapshot, getSystemTimeSeries, getLatestRouteSnapshots, getLatestRailSnapshots, getRouteTimeSeries } from "../data/metrics.js";
+import { fetchArrivals } from "../rail/api.js";
 
 const app = new Hono();
 
@@ -413,6 +414,17 @@ app.get("/metrics/route/:routeId", (c) => {
   if (!ROUTE_ID_RE.test(routeId)) return c.json({ error: "Invalid routeId" }, 400);
   const hours = Math.min(168, Math.max(1, parseInt(c.req.query("hours") || "24")));
   return c.json(getRouteTimeSeries(routeId, hours));
+});
+
+// ── Rail ──
+
+// GET /api/rail — JSON endpoint (real-time rail arrivals)
+app.get("/rail", async (c) => {
+  const arrivals = await fetchArrivals();
+  return c.json({
+    arrivals,
+    timestamp: Date.now(),
+  });
 });
 
 export default app;

--- a/src/routes/bus.tsx
+++ b/src/routes/bus.tsx
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { Layout } from "../views/Layout.js";
 import { BusTrackerPage } from "../views/pages/BusTracker.js";
+import { ErrorPage } from "../views/pages/ErrorPage.js";
 import { getRoute, getStop, getRouteDetail, getRoutesForStop } from "../data/db.js";
 
 const app = new Hono();
@@ -70,33 +71,23 @@ app.get("/bus", async (c) => {
 
     if (!route) {
       return c.html(
-        <Layout title="Route Not Found — Pullcord">
-          <div class="min-h-screen bg-gray-50 flex items-center justify-center">
-            <div class="text-center">
-              <h1 class="text-2xl font-bold text-gray-900 mb-4">Route Not Found</h1>
-              <p class="text-gray-600 mb-6">The route "{routeId}" could not be found.</p>
-              <a href="/" class="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700">
-                ← Back to Home
-              </a>
-            </div>
-          </div>
-        </Layout>
+        <ErrorPage
+          title="Route Not Found — Pullcord"
+          heading="Route Not Found"
+          message={`The route "${routeId}" could not be found.`}
+        />,
+        404,
       );
     }
 
     if (!stop) {
       return c.html(
-        <Layout title="Stop Not Found — Pullcord">
-          <div class="min-h-screen bg-gray-50 flex items-center justify-center">
-            <div class="text-center">
-              <h1 class="text-2xl font-bold text-gray-900 mb-4">Stop Not Found</h1>
-              <p class="text-gray-600 mb-6">The stop "{stopId}" could not be found.</p>
-              <a href="/" class="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700">
-                ← Back to Home
-              </a>
-            </div>
-          </div>
-        </Layout>
+        <ErrorPage
+          title="Stop Not Found — Pullcord"
+          heading="Stop Not Found"
+          message={`The stop "${stopId}" could not be found.`}
+        />,
+        404,
       );
     }
 
@@ -148,19 +139,14 @@ app.get("/bus", async (c) => {
 
   } catch (error) {
     console.error("Error rendering bus tracker page:", error);
-    
+
     return c.html(
-      <Layout title="Error — Pullcord">
-        <div class="min-h-screen bg-gray-50 flex items-center justify-center">
-          <div class="text-center">
-            <h1 class="text-2xl font-bold text-gray-900 mb-4">Something went wrong</h1>
-            <p class="text-gray-600 mb-6">Unable to load the bus tracker. Please try again.</p>
-            <a href="/" class="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700">
-              ← Back to Home
-            </a>
-          </div>
-        </div>
-      </Layout>
+      <ErrorPage
+        title="Error — Pullcord"
+        heading="Something went wrong"
+        message="Unable to load the bus tracker. Please try again."
+      />,
+      500,
     );
   }
 });

--- a/src/routes/rail.tsx
+++ b/src/routes/rail.tsx
@@ -96,13 +96,4 @@ app.get("/rail/:slug", async (c) => {
   );
 });
 
-// GET /api/rail — JSON endpoint
-app.get("/api/rail", async (c) => {
-  const arrivals = await fetchArrivals();
-  return c.json({
-    arrivals,
-    timestamp: Date.now(),
-  });
-});
-
 export default app;

--- a/src/views/Layout.tsx
+++ b/src/views/Layout.tsx
@@ -3,7 +3,7 @@ import { createHash } from "crypto";
 import { readFileSync } from "fs";
 
 // Cache-bust: hash static assets at startup so deploys get fresh files
-function fileHash(path: string): string {
+export function fileHash(path: string): string {
   try {
     const content = readFileSync(path);
     return createHash("md5").update(content).digest("hex").slice(0, 8);
@@ -11,6 +11,7 @@ function fileHash(path: string): string {
 }
 const JS_HASH = fileHash("public/app.js");
 const CSS_HASH = fileHash("public/styles.css");
+const ETA_HASH = fileHash("public/eta.js");
 const OG_HASH = fileHash("public/icons/og-image.png");
 
 export interface LayoutProps {
@@ -90,7 +91,7 @@ export const Layout = (props: LayoutProps) => {
         ></script>
 
         {/* App JS */}
-        <script src="/public/eta.js"></script>
+        <script src={`/public/eta.js?v=${ETA_HASH}`}></script>
         <script src={`/public/app.js?v=${JS_HASH}`}></script>
 
         {/* Push SW is registered on-demand by Pull the Cord — no page-load SW */}

--- a/src/views/pages/ErrorPage.tsx
+++ b/src/views/pages/ErrorPage.tsx
@@ -1,0 +1,58 @@
+/**
+ * Shared error / 404 page — standalone (no Layout wrapper).
+ * Matches the app's dark theme so errors don't flash a jarring light page.
+ */
+export interface ErrorPageProps {
+  title: string;
+  heading: string;
+  message: string;
+  showHomeLink?: boolean;
+}
+
+export const ErrorPage = ({ title, heading, message, showHomeLink = true }: ErrorPageProps) => (
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>{title}</title>
+      <style>{`
+        body {
+          font-family: system-ui, -apple-system, sans-serif;
+          text-align: center;
+          padding: 50px 20px;
+          margin: 0;
+          background: #0f0f0f;
+          color: #e5e5e5;
+        }
+        .error {
+          max-width: 400px;
+          margin: 0 auto;
+        }
+        h1 {
+          color: #f87171;
+          font-size: 1.5rem;
+          margin-bottom: 0.75rem;
+        }
+        p {
+          color: #a3a3a3;
+          margin: 16px 0;
+          line-height: 1.5;
+        }
+        a {
+          color: #60a5fa;
+          text-decoration: none;
+        }
+        a:hover {
+          text-decoration: underline;
+        }
+      `}</style>
+    </head>
+    <body>
+      <div class="error">
+        <h1>{heading}</h1>
+        <p>{message}</p>
+        {showHomeLink && <p><a href="/">&larr; Back to Home</a></p>}
+      </div>
+    </body>
+  </html>
+);

--- a/src/views/pages/Explore.tsx
+++ b/src/views/pages/Explore.tsx
@@ -1,3 +1,7 @@
+import { fileHash } from "../Layout.js";
+
+const EXPLORE_HASH = fileHash("public/explore.js");
+
 export const ExplorePage = () => (
   <div class="explore-shell">
     {/* Header bar with integrated search */}
@@ -34,6 +38,6 @@ export const ExplorePage = () => (
     </div>
 
     {/* Inline script to bootstrap the map */}
-    <script src="/public/explore.js"></script>
+    <script src={`/public/explore.js?v=${EXPLORE_HASH}`}></script>
   </div>
 );

--- a/src/views/pages/Ride.tsx
+++ b/src/views/pages/Ride.tsx
@@ -1,3 +1,7 @@
+import { fileHash } from "../Layout.js";
+
+const RIDE_HASH = fileHash("public/ride.js");
+
 export const RidePage = ({ tripId, stopId, routeId }: { tripId: string; stopId: string; routeId: string }) => (
   <div class="ride-shell">
     {/* Header */}
@@ -40,6 +44,6 @@ export const RidePage = ({ tripId, stopId, routeId }: { tripId: string; stopId: 
     <script dangerouslySetInnerHTML={{ __html: `
       window.__RIDE_CONFIG__ = ${JSON.stringify({ tripId, stopId, routeId })};
     ` }} />
-    <script src="/public/ride.js"></script>
+    <script src={`/public/ride.js?v=${RIDE_HASH}`}></script>
   </div>
 );


### PR DESCRIPTION
## Summary

Addresses the top 3 checklist items from #71.

- **Shared error page**: New `ErrorPage.tsx` component with dark theme styling (no Layout wrapper — avoids pulling full asset set on errors). Replaces inline HTML strings in `app.ts` and off-brand light-theme markup in `bus.tsx`. Bus error responses now also return proper 404/500 status codes.
- **Cache-bust all client scripts**: Exported `fileHash()` from Layout and applied `?v=` cache-bust params to `eta.js`, `explore.js`, and `ride.js` — previously only `app.js` and `styles.css` had them, so these three scripts could serve stale content after deploy.
- **Move `/api/rail` to `api.ts`**: Moved the rail JSON endpoint from `rail.tsx` to `api.ts` where it belongs. Route path resolves identically (`/api/rail`) since the api router is mounted at `/api`.

## Test plan

- [x] All 27 existing tests pass
- [ ] Visit a bogus URL — should see dark-themed 404 page
- [ ] Visit `/bus?route=FAKE&stop=999` — should see dark-themed "Route Not Found" with 404 status
- [ ] Verify `/api/rail` still returns JSON rail arrivals
- [ ] Check page source for `explore.js?v=`, `ride.js?v=`, `eta.js?v=` cache-bust params

---
_Generated by [Claude Code](https://claude.ai/code/session_016qro8HV4wqNZZTNLArCJFp)_