### PR TITLE
Consolidate client-side esc() and rail colors

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1146,6 +1146,7 @@ class PullcordApp {
 
   renderRailRow(pred) {
     const minutes = Math.floor(pred.etaSeconds / 60);
+    // Source of truth: src/data/rail-colors.ts (dark palette). Keep in sync.
     const lineColors = { RED: '#E05555', GOLD: '#D4A020', BLUE: '#4A9FE5', GREEN: '#3BAA6E' };
     const color = lineColors[pred.line] || '#888';
     const isScheduled = !pred.isRealtime;
@@ -1772,7 +1773,7 @@ class PullcordApp {
   }
 
   dist(lat1, lon1, lat2, lon2) {
-    // Simple equirectangular approximation (fine for short distances)
+    // Equirectangular approx — intentionally differs from ride.js's Haversine (see issue #68)
     const R = 6371000;
     const dLat = (lat2 - lat1) * Math.PI / 180;
     const dLon = (lon2 - lon1) * Math.PI / 180;

--- a/public/eta.js
+++ b/public/eta.js
@@ -1,5 +1,5 @@
 // Pure ETA computation — no dependencies.
-// Mirrors src/data/eta.ts for client-side use.
+// Mirrors src/data/eta.ts for client-side use; terminal branch intentionally differs (see issue #68).
 
 /**
  * Parse HH:MM:SS to seconds since midnight. GTFS allows H > 23 for overnight.

--- a/public/explore.js
+++ b/public/explore.js
@@ -333,11 +333,7 @@
 
   // ─── Utilities ───
 
-  function esc(str) {
-    const el = document.createElement('span');
-    el.textContent = str;
-    return el.innerHTML;
-  }
+  const esc = window.esc;
 
   function debounce(fn, ms) {
     let timer;

--- a/public/explore.js
+++ b/public/explore.js
@@ -333,7 +333,7 @@
 
   // ─── Utilities ───
 
-  const esc = window.esc;
+  const esc = window.esc || function(s) { const e = document.createElement('span'); e.textContent = s; return e.innerHTML; };
 
   function debounce(fn, ms) {
     let timer;

--- a/public/ride.js
+++ b/public/ride.js
@@ -397,7 +397,7 @@
     return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   }
 
-  const esc = window.esc;
+  const esc = window.esc || function(s) { const e = document.createElement('span'); e.textContent = s; return e.innerHTML; };
 
   // ─── Boot ───
   if (document.readyState === 'loading') {

--- a/public/ride.js
+++ b/public/ride.js
@@ -397,11 +397,7 @@
     return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   }
 
-  function esc(str) {
-    const el = document.createElement('span');
-    el.textContent = str;
-    return el.innerHTML;
-  }
+  const esc = window.esc;
 
   // ─── Boot ───
   if (document.readyState === 'loading') {

--- a/public/shared.js
+++ b/public/shared.js
@@ -1,0 +1,9 @@
+// Shared client-side utilities.
+// Loaded before page-specific scripts (explore.js, ride.js).
+
+/** DOM-based HTML escaping (safe for user-supplied text in innerHTML). */
+window.esc = function esc(str) {
+  const el = document.createElement('span');
+  el.textContent = str;
+  return el.innerHTML;
+};

--- a/src/data/rail-colors.ts
+++ b/src/data/rail-colors.ts
@@ -1,0 +1,9 @@
+// Canonical MARTA rail line colors — single source of truth.
+// Also used client-side in public/app.js (inlined since app.js cannot import TS).
+
+export const LINE_COLORS = {
+  RED: "#E05555",
+  GOLD: "#D4A020",
+  BLUE: "#4A9FE5",
+  GREEN: "#3BAA6E",
+} as const;

--- a/src/views/pages/Explore.tsx
+++ b/src/views/pages/Explore.tsx
@@ -1,5 +1,6 @@
 import { fileHash } from "../Layout.js";
 
+const SHARED_HASH = fileHash("public/shared.js");
 const EXPLORE_HASH = fileHash("public/explore.js");
 
 export const ExplorePage = () => (
@@ -38,6 +39,7 @@ export const ExplorePage = () => (
     </div>
 
     {/* Inline script to bootstrap the map */}
+    <script src={`/public/shared.js?v=${SHARED_HASH}`}></script>
     <script src={`/public/explore.js?v=${EXPLORE_HASH}`}></script>
   </div>
 );

--- a/src/views/pages/Ride.tsx
+++ b/src/views/pages/Ride.tsx
@@ -1,5 +1,6 @@
 import { fileHash } from "../Layout.js";
 
+const SHARED_HASH = fileHash("public/shared.js");
 const RIDE_HASH = fileHash("public/ride.js");
 
 export const RidePage = ({ tripId, stopId, routeId }: { tripId: string; stopId: string; routeId: string }) => (
@@ -44,6 +45,7 @@ export const RidePage = ({ tripId, stopId, routeId }: { tripId: string; stopId: 
     <script dangerouslySetInnerHTML={{ __html: `
       window.__RIDE_CONFIG__ = ${JSON.stringify({ tripId, stopId, routeId })};
     ` }} />
+    <script src={`/public/shared.js?v=${SHARED_HASH}`}></script>
     <script src={`/public/ride.js?v=${RIDE_HASH}`}></script>
   </div>
 );

--- a/src/views/pages/rail/data.ts
+++ b/src/views/pages/rail/data.ts
@@ -1,13 +1,6 @@
 import type { RailArrival } from "../../../rail/api.js";
 import { stationSlug, stationDisplayName } from "../../../rail/api.js";
-
-// ── Accessible line colors ──
-export const LINE_COLORS = {
-  RED: "#E05555",
-  GOLD: "#D4A020",
-  BLUE: "#4A9FE5",
-  GREEN: "#3BAA6E",
-};
+export { LINE_COLORS } from "../../../data/rail-colors.js";
 
 // ── Station orderings for train timeline (north→south per line) ──
 export const LINE_STATIONS: Record<string, string[]> = {


### PR DESCRIPTION
## Summary
- **`esc()` dedupe**: Hoisted identical DOM-based `esc()` from `explore.js` and `ride.js` into `public/shared.js`; loaded via `<script>` before page scripts. Did NOT merge with `app.js`'s regex-based version (different escaping behavior).
- **Rail colors**: Created `src/data/rail-colors.ts` as single source of truth; `Rail.tsx` now imports from it. Added pointer comment in `app.js` (can't import TS).
- **Judgment items documented**: Added one-line comments on `dist()` (equirectangular vs Haversine) and `eta.js` (terminal branch divergence) — not unified, just documented.

Partially addresses #68 (mechanical items only)

## Test plan
- [ ] `bun test` passes (27 tests)
- [ ] `bunx tsc --noEmit` passes (no new errors)
- [ ] Explore page: stop names with special chars (`<`, `"`) render correctly
- [ ] Ride page: same escaping check
- [ ] Rail page: line colors render correctly in dark/light modes

https://claude.ai/code/session_012FWbSCeZDFfxCHBmHQZ7UA

---
_Generated by [Claude Code](https://claude.ai/code/session_012FWbSCeZDFfxCHBmHQZ7UA)_